### PR TITLE
Prevent file log tests from starting the log twice

### DIFF
--- a/src/test/java/com/tesco/mewbase/log/impl/file/LogTestBase.java
+++ b/src/test/java/com/tesco/mewbase/log/impl/file/LogTestBase.java
@@ -66,7 +66,6 @@ public class LogTestBase extends MewbaseTestBase {
         flm = new FileLogManager(vertx, options, faf);
         flm.createLog(TEST_CHANNEL_1).thenCompose(l -> flm.createLog(TEST_CHANNEL_2)).get();
         log = flm.getLog(channel);
-        log.start().get();
     }
 
     protected void saveInfo(int fileNumber, int headPos, int fileHeadPos, boolean shutdown) {


### PR DESCRIPTION
`LogTestbase` was calling `log.start()` explicitly, but the FileLog has already been started as part of the `createLog` call.

This was resulting in FileLog opening the file twice (and so creating two file handles). Ultimately this caused the `test_start_with_zeroed_info_file_but_no_log_file` test to fail on Windows platforms, because only one of the two file handles was being closed and Windows will not properly delete a file whilst there is still an open handle for it ([stackoverflow](http://stackoverflow.com/a/31608180)).

This PR just fixes the way the tests are using the file logs, but to prevent similar issues elsewhere it might be sensible to store an `isStarted` flag on `FileLog` to prevent duplicate file opening. Do you agree? If so, I'll add another commit with that...