### PR TITLE
Add travis build #50

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: java
+jdk:
+- oraclejdk8
+script:
+- mvn clean package
+branches:
+  only:
+    - master

--- a/README.MD
+++ b/README.MD
@@ -1,4 +1,5 @@
 ﻿# mewbase
+[![Build Status](https://travis-ci.org/Tesco/mewbase.svg)](https://travis-ci.org/Tesco/mewbase)
 
 ## The problem
 


### PR DESCRIPTION
Travis is configured using a file called '.travis.yml' at the root of the repo. 
This file specifies the language in our case Java and the desired building and testing environment (maven build).
Travis needs to authorize to the projects' github account in order to work.
When a commit is pushed the build is triggered automatically. Also pull requests could be built like that.
Then depending on the build outcome developers can be notified (either via email , IRC, slack etc)

