### PR TITLE
Ported Binders to Lmdbjava

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,20 +47,11 @@
 
 
         <dependency>
-            <groupId>org.deephacks.lmdbjni</groupId>
-            <artifactId>lmdbjni-linux64</artifactId>
-            <version>0.4.6</version>
+            <groupId>org.lmdbjava</groupId>
+            <artifactId>lmdbjava</artifactId>
+            <version>0.0.5</version>
         </dependency>
-        <dependency>
-            <groupId>org.deephacks.lmdbjni</groupId>
-            <artifactId>lmdbjni-osx64</artifactId>
-            <version>0.4.6</version>
-        </dependency>
-        <dependency>
-            <groupId>org.deephacks.lmdbjni</groupId>
-            <artifactId>lmdbjni-win64</artifactId>
-            <version>0.4.6</version>
-        </dependency>
+
 
         <dependency>
             <groupId>io.vertx</groupId>

--- a/src/main/java/io/mewbase/server/Binder.java
+++ b/src/main/java/io/mewbase/server/Binder.java
@@ -4,6 +4,7 @@ import io.mewbase.bson.BsonObject;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
+import java.util.function.Predicate;
 
 /**
  * Created by tim on 29/12/16.
@@ -17,9 +18,9 @@ public interface Binder {
     /**
      * Get a document in a named binder matching the filter
      *
-     * @param matcher matching projection for documents
+     * @param filter matching projection for documents
      */
-    DocReadStream getMatching(Function<BsonObject, Boolean> matcher);
+    DocReadStream getMatching(Predicate<BsonObject> filter);
 
     /**
      * Get a document  with the given id

--- a/src/main/java/io/mewbase/server/impl/ConnectionImpl.java
+++ b/src/main/java/io/mewbase/server/impl/ConnectionImpl.java
@@ -523,7 +523,7 @@ public class ConnectionImpl implements ServerFrameHandler {
     protected Buffer writeResponse(String frameName, BsonObject frame) {
 
         Buffer buff = Protocol.encodeFrame(frameName, frame);
-        System.out.println("WritBuf :" + buff.toString());
+        //System.out.println("WritBuf :" + buff.toString());
         // TODO compare performance of writing directly in all cases and via context
         Context curr = Vertx.currentContext();
         if (curr != context) {

--- a/src/main/java/io/mewbase/server/impl/ConnectionImpl.java
+++ b/src/main/java/io/mewbase/server/impl/ConnectionImpl.java
@@ -523,6 +523,7 @@ public class ConnectionImpl implements ServerFrameHandler {
     protected Buffer writeResponse(String frameName, BsonObject frame) {
 
         Buffer buff = Protocol.encodeFrame(frameName, frame);
+        System.out.println("WritBuf :" + buff.toString());
         // TODO compare performance of writing directly in all cases and via context
         Context curr = Vertx.currentContext();
         if (curr != context) {

--- a/src/main/java/io/mewbase/server/impl/Protocol.java
+++ b/src/main/java/io/mewbase/server/impl/Protocol.java
@@ -153,7 +153,7 @@ public class Protocol {
         // TODO bit clunky - need to add size back in so it can be decoded, improve this!
         Buffer buff2 = Buffer.buffer(buffer.length() + 4);
         buff2.appendIntLE(size + 4).appendBuffer(buffer);
-    System.out.println("ReadBuf :" + buff2.toString());
+    //System.out.println("ReadBuf :" + buff2.toString());
         BsonObject bson = new BsonObject(buff2);
         handleBson(size, bson);
     }

--- a/src/main/java/io/mewbase/server/impl/Protocol.java
+++ b/src/main/java/io/mewbase/server/impl/Protocol.java
@@ -153,6 +153,7 @@ public class Protocol {
         // TODO bit clunky - need to add size back in so it can be decoded, improve this!
         Buffer buff2 = Buffer.buffer(buffer.length() + 4);
         buff2.appendIntLE(size + 4).appendBuffer(buffer);
+    System.out.println("ReadBuf :" + buff2.toString());
         BsonObject bson = new BsonObject(buff2);
         handleBson(size, bson);
     }

--- a/src/main/java/io/mewbase/server/impl/ServerImpl.java
+++ b/src/main/java/io/mewbase/server/impl/ServerImpl.java
@@ -321,6 +321,7 @@ public class ServerImpl implements Server {
             stream.handler(doc -> {
                 docs.add(doc);
                 if (!stream.hasMore()) {
+                    stream.close();
                     cf.complete(docs);
                 }
             });

--- a/src/main/java/io/mewbase/server/impl/SubscriptionImpl.java
+++ b/src/main/java/io/mewbase/server/impl/SubscriptionImpl.java
@@ -30,7 +30,6 @@ public class SubscriptionImpl extends SubscriptionBase {
         frame = frame.copy();
         frame.put(Protocol.RECEV_SUBID, id);
         frame.put(Protocol.RECEV_POS, pos);
-        logger.trace("sub delivering " + frame);
         Buffer buff = connection.writeResponse(Protocol.RECEV_FRAME, frame);
         unackedBytes += buff.length();
         if (unackedBytes > maxUnackedBytes) {

--- a/src/main/java/io/mewbase/server/impl/SubscriptionImpl.java
+++ b/src/main/java/io/mewbase/server/impl/SubscriptionImpl.java
@@ -30,6 +30,7 @@ public class SubscriptionImpl extends SubscriptionBase {
         frame = frame.copy();
         frame.put(Protocol.RECEV_SUBID, id);
         frame.put(Protocol.RECEV_POS, pos);
+        logger.trace("sub delivering " + frame);
         Buffer buff = connection.writeResponse(Protocol.RECEV_FRAME, frame);
         unackedBytes += buff.length();
         if (unackedBytes > maxUnackedBytes) {

--- a/src/main/java/io/mewbase/server/impl/doc/lmdb/LmdbBinder.java
+++ b/src/main/java/io/mewbase/server/impl/doc/lmdb/LmdbBinder.java
@@ -69,6 +69,7 @@ public class LmdbBinder implements Binder {
     @Override
     public CompletableFuture<Void> put(String id, BsonObject doc) {
         AsyncResCF<Void> res = new AsyncResCF<>();
+        logger.trace("Submitting put " + id);
         binderFactory.getExec().executeBlocking(fut -> {
             ByteBuffer key = getKey(id);
             logger.trace("Putting key " + id);

--- a/src/main/java/io/mewbase/server/impl/doc/lmdb/LmdbBinder.java
+++ b/src/main/java/io/mewbase/server/impl/doc/lmdb/LmdbBinder.java
@@ -19,6 +19,7 @@ import java.util.function.Function;
 
 import static java.nio.ByteBuffer.allocateDirect;
 
+
 /**
  * Created by tim on 29/12/16.
  */

--- a/src/main/java/io/mewbase/server/impl/doc/lmdb/LmdbBinder.java
+++ b/src/main/java/io/mewbase/server/impl/doc/lmdb/LmdbBinder.java
@@ -16,6 +16,7 @@ import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
+import java.util.function.Predicate;
 
 import static java.nio.ByteBuffer.allocateDirect;
 
@@ -38,8 +39,8 @@ public class LmdbBinder implements Binder {
     }
 
     @Override
-    public DocReadStream getMatching(Function<BsonObject, Boolean> matcher) {
-        return new LmdbReadStream(binderFactory, db, matcher);
+    public DocReadStream getMatching(Predicate<BsonObject> filter) {
+        return new LmdbReadStream(binderFactory, db, filter);
     }
 
     @Override

--- a/src/main/java/io/mewbase/server/impl/doc/lmdb/LmdbBinder.java
+++ b/src/main/java/io/mewbase/server/impl/doc/lmdb/LmdbBinder.java
@@ -52,9 +52,10 @@ public class LmdbBinder implements Binder {
                 ByteBuffer key = getKey(id);
                 final ByteBuffer found = db.get(txn, key);
                 if (found != null) {
-                    byte [] local = new byte[txn.val().remaining()];
-                    txn.val().get(local);
-                    BsonObject doc = new BsonObject(Buffer.buffer(local));
+                    // copy to local Vert.x buffer from the LMDB mem managed array
+                    Buffer buffer = Buffer.buffer(txn.val().remaining());
+                    buffer.setBytes( 0 , txn.val() );
+                    BsonObject doc = new BsonObject(buffer);
                     fut.complete(doc);
                 } else {
                     fut.complete(null);

--- a/src/main/java/io/mewbase/server/impl/doc/lmdb/LmdbBinder.java
+++ b/src/main/java/io/mewbase/server/impl/doc/lmdb/LmdbBinder.java
@@ -71,6 +71,7 @@ public class LmdbBinder implements Binder {
         AsyncResCF<Void> res = new AsyncResCF<>();
         binderFactory.getExec().executeBlocking(fut -> {
             ByteBuffer key = getKey(id);
+            logger.trace("Putting key " + id);
             byte[] valBytes = doc.encode().getBytes();
             final ByteBuffer val = allocateDirect(valBytes.length);
             val.put(valBytes).flip();

--- a/src/main/java/io/mewbase/server/impl/doc/lmdb/LmdbBinder.java
+++ b/src/main/java/io/mewbase/server/impl/doc/lmdb/LmdbBinder.java
@@ -46,7 +46,7 @@ public class LmdbBinder implements Binder {
     public CompletableFuture<BsonObject> get(String id) {
         AsyncResCF<BsonObject> res = new AsyncResCF<>();
         binderFactory.getExec().executeBlocking(fut -> {
-            // in oreder to do a read we have to do it under a txn so use
+            // in order to do a read we have to do it under a txn so use
             // try with resource to get the auto close magic.
             try (Txn<ByteBuffer> txn = binderFactory.getEnv().txnRead()) {
                 ByteBuffer key = getKey(id);

--- a/src/main/java/io/mewbase/server/impl/doc/lmdb/LmdbBinder.java
+++ b/src/main/java/io/mewbase/server/impl/doc/lmdb/LmdbBinder.java
@@ -29,8 +29,6 @@ public class LmdbBinder implements Binder {
 
     private final static Logger logger = LoggerFactory.getLogger(LmdbBinder.class);
 
-    private static final String LMDB_DOCMANAGER_POOL_NAME = "mewbase.docmanagerpool";
-
     private final LmdbBinderFactory binderFactory;
     private final String name;
     private Dbi<ByteBuffer> db;
@@ -40,9 +38,7 @@ public class LmdbBinder implements Binder {
     public LmdbBinder(LmdbBinderFactory binderFactory, String name) {
         this.binderFactory = binderFactory;
         this.name = name;
-        // TODO - would be better to maintain a pool of single threaded executors and assign them round robin to
-        // binders to avoid each binder having its own thread
-        exec = binderFactory.getVertx().createSharedWorkerExecutor(LMDB_DOCMANAGER_POOL_NAME + "." + name, 1);
+        exec = binderFactory.getSingleWorkerExecutor();
     }
 
     @Override

--- a/src/main/java/io/mewbase/server/impl/doc/lmdb/LmdbBinderFactory.java
+++ b/src/main/java/io/mewbase/server/impl/doc/lmdb/LmdbBinderFactory.java
@@ -54,7 +54,7 @@ public class LmdbBinderFactory implements BinderFactory {
             env = Env.<ByteBuffer>create()
                     .setMapSize(maxDBSize)
                     .setMaxDbs(maxDBs)
-                    .setMaxReaders(1024 * 1024)
+                    .setMaxReaders(1024)
                     .open(fDocsDir, Integer.MAX_VALUE, MDB_NOTLS);  // TODO Check size is correct default
             fut.complete(null);
         }, res);

--- a/src/main/java/io/mewbase/server/impl/doc/lmdb/LmdbBinderFactory.java
+++ b/src/main/java/io/mewbase/server/impl/doc/lmdb/LmdbBinderFactory.java
@@ -41,7 +41,7 @@ public class LmdbBinderFactory implements BinderFactory {
         this.maxDBs = serverOptions.getMaxBinders();
         this.maxDBSize = serverOptions.getMaxBinderSize();
         this.vertx = vertx;
-        // This exec is only usedf for opening or closing the env
+        // This exec is only used for opening or closing the env
         exec = vertx.createSharedWorkerExecutor(LMDB_DOCMANAGER_POOL_NAME, 1);
     }
 

--- a/src/main/java/io/mewbase/server/impl/doc/lmdb/LmdbBinderFactory.java
+++ b/src/main/java/io/mewbase/server/impl/doc/lmdb/LmdbBinderFactory.java
@@ -27,7 +27,7 @@ public class LmdbBinderFactory implements BinderFactory {
     private final static Logger logger = LoggerFactory.getLogger(LmdbBinderFactory.class);
 
     private static final String LMDB_DOCMANAGER_POOL_NAME = "mewbase.docmanagerpool";
-    private static final int LMDB_DOCMANAGER_POOL_SIZE = 10;
+    private static final int LMDB_DOCMANAGER_POOL_SIZE = 1;
 
     private final String docsDir;
     private final int maxDBs;

--- a/src/main/java/io/mewbase/server/impl/doc/lmdb/LmdbBinderFactory.java
+++ b/src/main/java/io/mewbase/server/impl/doc/lmdb/LmdbBinderFactory.java
@@ -27,7 +27,6 @@ public class LmdbBinderFactory implements BinderFactory {
     private final static Logger logger = LoggerFactory.getLogger(LmdbBinderFactory.class);
 
     private static final String LMDB_DOCMANAGER_POOL_NAME = "mewbase.docmanagerpool";
-    private static final int LMDB_DOCMANAGER_POOL_SIZE = 1;
 
     private final String docsDir;
     private final int maxDBs;
@@ -42,7 +41,8 @@ public class LmdbBinderFactory implements BinderFactory {
         this.maxDBs = serverOptions.getMaxBinders();
         this.maxDBSize = serverOptions.getMaxBinderSize();
         this.vertx = vertx;
-        exec = vertx.createSharedWorkerExecutor(LMDB_DOCMANAGER_POOL_NAME, LMDB_DOCMANAGER_POOL_SIZE);
+        // This exec is only usedf for opening or closing the env
+        exec = vertx.createSharedWorkerExecutor(LMDB_DOCMANAGER_POOL_NAME, 1);
     }
 
     @Override
@@ -80,10 +80,6 @@ public class LmdbBinderFactory implements BinderFactory {
 
     Vertx getVertx() {
         return vertx;
-    }
-
-    WorkerExecutor getExec() {
-        return exec;
     }
 
     Env getEnv() {

--- a/src/main/java/io/mewbase/server/impl/doc/lmdb/LmdbReadStream.java
+++ b/src/main/java/io/mewbase/server/impl/doc/lmdb/LmdbReadStream.java
@@ -55,7 +55,6 @@ public class LmdbReadStream implements DocReadStream {
 
     LmdbReadStream(LmdbBinderFactory binderFactory, Dbi<ByteBuffer> db, Predicate<BsonObject> filter) {
         this.binderFactory = binderFactory;
-        // System.out.println("Open txn :" + openTxnCount.incrementAndGet());
         this.txn = binderFactory.getEnv().txnRead(); // set uo a read transaction
         this.cursorItr = db.iterate(txn, FORWARD);
         this.itr = cursorItr.iterable().iterator();
@@ -117,7 +116,7 @@ public class LmdbReadStream implements DocReadStream {
     // all seg faults
     private void runIterNextAsync() {
         AsyncResCF<Void> res = new AsyncResCF<>();
-        binderFactory.getExec().executeBlocking(fut -> {
+        exec.executeBlocking(fut -> {
             iterNext();
             fut.complete(null);
         }, res);

--- a/src/main/java/io/mewbase/server/impl/doc/lmdb/LmdbReadStream.java
+++ b/src/main/java/io/mewbase/server/impl/doc/lmdb/LmdbReadStream.java
@@ -135,6 +135,7 @@ public class LmdbReadStream implements DocReadStream {
                 Buffer buffer = Buffer.buffer(kv.val().remaining());
                 buffer.setBytes(0, kv.val());
                 BsonObject doc = new BsonObject(buffer);
+                logger.trace("Reading doc " + doc);
                 if (handler != null && filter.test(doc)) {
                     handler.accept(doc);
                     handledOne = true;

--- a/src/main/java/io/mewbase/server/impl/log/LogImpl.java
+++ b/src/main/java/io/mewbase/server/impl/log/LogImpl.java
@@ -89,7 +89,7 @@ public class LogImpl implements Log {
         if (!currFile.exists()) {
             if (fileNumber == 0 && filePos == 0) {
                 // This is OK, new log
-                logger.trace("Creating new log info file for channel {}", channel);
+                logger.trace("Creating new log file for channel {}", channel);
                 // Create a new first file
                 cfCreate = createAndFillFile(getFileName(channel,0));
             }

--- a/src/main/java/io/mewbase/server/impl/log/LogImpl.java
+++ b/src/main/java/io/mewbase/server/impl/log/LogImpl.java
@@ -104,7 +104,7 @@ public class LogImpl implements Log {
         }
         startRes = cf.thenAccept(bf -> {
             currWriteFile = bf;
-            logger.trace("Opened file log " + this);
+            logger.trace("Started file log for channel {}", channel);
         }).thenRun(this::scheduleFlush);
 
         return startRes;

--- a/src/main/java/io/mewbase/server/impl/proj/ProjectionManager.java
+++ b/src/main/java/io/mewbase/server/impl/proj/ProjectionManager.java
@@ -95,8 +95,6 @@ public class ProjectionManager {
 
             String docID = docIDSelector.apply(event);
 
-            logger.trace("projection manager receiving " + docID + " thread " + Thread.currentThread());
-
             if (docID == null) {
                 throw new IllegalArgumentException("No doc ID found in event " + event);
             }
@@ -147,7 +145,6 @@ public class ProjectionManager {
                         lastSeqs.put(name, seq);
 
                         // Store the doc
-                        logger.trace("Putting doc from binder " + docID + " thread " + Thread.currentThread());
                         CompletableFuture<Void> cfSaved = binder.put(docID, updated);
                         return cfSaved.thenApply(v -> true);
                     })

--- a/src/main/java/io/mewbase/server/impl/proj/ProjectionSubscription.java
+++ b/src/main/java/io/mewbase/server/impl/proj/ProjectionSubscription.java
@@ -4,6 +4,9 @@ import io.mewbase.bson.BsonObject;
 import io.mewbase.common.SubDescriptor;
 import io.mewbase.server.impl.ServerImpl;
 import io.mewbase.server.impl.SubscriptionBase;
+import io.mewbase.server.impl.SubscriptionImpl;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.function.BiConsumer;
 
@@ -11,6 +14,9 @@ import java.util.function.BiConsumer;
  * Created by tim on 24/11/16.
  */
 public class ProjectionSubscription extends SubscriptionBase {
+
+    private final static Logger logger = LoggerFactory.getLogger(ProjectionSubscription.class);
+
 
     private final int maxUnackedEvents;
     private final BiConsumer<Long, BsonObject> frameHandler;
@@ -25,6 +31,7 @@ public class ProjectionSubscription extends SubscriptionBase {
 
     @Override
     protected void onReceiveFrame(long pos, BsonObject frame) {
+        logger.trace("Projection sub receiving " + frame);
         unackedEvents++;
         if (unackedEvents > maxUnackedEvents) {
             readStream.pause();

--- a/src/main/java/io/mewbase/server/impl/proj/ProjectionSubscription.java
+++ b/src/main/java/io/mewbase/server/impl/proj/ProjectionSubscription.java
@@ -31,7 +31,6 @@ public class ProjectionSubscription extends SubscriptionBase {
 
     @Override
     protected void onReceiveFrame(long pos, BsonObject frame) {
-        logger.trace("Projection sub receiving " + frame);
         unackedEvents++;
         if (unackedEvents > maxUnackedEvents) {
             readStream.pause();

--- a/src/main/java/io/mewbase/util/SizedExecutorPool.java
+++ b/src/main/java/io/mewbase/util/SizedExecutorPool.java
@@ -1,0 +1,32 @@
+package io.mewbase.util;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.WorkerExecutor;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class SizedExecutorPool {
+
+    private final String name;
+    private final int size;
+    private final List<WorkerExecutor> pool;
+    private final Vertx vertx;
+
+    private AtomicInteger accessCounter = new AtomicInteger(0);
+
+    public SizedExecutorPool(Vertx vertx, String poolName, int poolSize) {
+        if (poolSize < 1) throw new AssertionError("Executor pool size must be at least 1");
+        this.vertx = vertx;
+        name = poolName;
+        size = poolSize;
+        pool = new ArrayList<>(poolSize);
+    }
+
+    public synchronized WorkerExecutor getWorkerExecutor() {
+        if (accessCounter.get() < size) pool.add(vertx.createSharedWorkerExecutor(name, 1));
+        return pool.get(accessCounter.getAndIncrement() % size);
+    }
+
+}

--- a/src/test/java/io/mewbase/QueryTest.java
+++ b/src/test/java/io/mewbase/QueryTest.java
@@ -85,6 +85,7 @@ public class QueryTest extends ServerTestBase {
         client.executeQuery("testQuery", new BsonObject(), qr -> {
             String expectedID = getID(cnt.getAndIncrement());
             context.assertEquals(expectedID, qr.document().getString("id"));
+    System.out.println(qr.document().getString("id"));
             cnt.getAndIncrement();
             if (cnt.get() == numDocs) {
                 context.assertTrue(qr.isLast());

--- a/src/test/java/io/mewbase/QueryTest.java
+++ b/src/test/java/io/mewbase/QueryTest.java
@@ -83,8 +83,9 @@ public class QueryTest extends ServerTestBase {
         Async async = context.async();
         AtomicInteger cnt = new AtomicInteger();
         client.executeQuery("testQuery", new BsonObject(), qr -> {
-            String expectedID = getID(cnt.getAndIncrement());
-            context.assertEquals(expectedID, qr.document().getString("id"));
+            //String expectedID = getID(cnt.getAndIncrement());
+            //context.assertEquals(expectedID, qr.document().getString("id"));
+            cnt.getAndIncrement();
             if (cnt.get() == numDocs) {
                 context.assertTrue(qr.isLast());
                 async.complete();

--- a/src/test/java/io/mewbase/QueryTest.java
+++ b/src/test/java/io/mewbase/QueryTest.java
@@ -85,7 +85,6 @@ public class QueryTest extends ServerTestBase {
         client.executeQuery("testQuery", new BsonObject(), qr -> {
             String expectedID = getID(cnt.getAndIncrement());
             context.assertEquals(expectedID, qr.document().getString("id"));
-    System.out.println(qr.document().getString("id"));
             cnt.getAndIncrement();
             if (cnt.get() == numDocs) {
                 context.assertTrue(qr.isLast());
@@ -94,6 +93,9 @@ public class QueryTest extends ServerTestBase {
                 context.assertFalse(qr.isLast());
             }
         }, t -> context.fail("Exception shouldn't be received"));
+
+
+        Thread.sleep(100);
     }
 
 

--- a/src/test/java/io/mewbase/QueryTest.java
+++ b/src/test/java/io/mewbase/QueryTest.java
@@ -65,7 +65,6 @@ public class QueryTest extends ServerTestBase {
         }
     }
 
-    @Repeat(value=1000)
     @Test
     public void testExecuteQuery(TestContext context) throws Exception {
         int numDocs = 100;

--- a/src/test/java/io/mewbase/QueryTest.java
+++ b/src/test/java/io/mewbase/QueryTest.java
@@ -85,7 +85,6 @@ public class QueryTest extends ServerTestBase {
         client.executeQuery("testQuery", new BsonObject(), qr -> {
             String expectedID = getID(cnt.getAndIncrement());
             context.assertEquals(expectedID, qr.document().getString("id"));
-            cnt.getAndIncrement();
             if (cnt.get() == numDocs) {
                 context.assertTrue(qr.isLast());
                 async.complete();

--- a/src/test/java/io/mewbase/QueryTest.java
+++ b/src/test/java/io/mewbase/QueryTest.java
@@ -66,7 +66,7 @@ public class QueryTest extends ServerTestBase {
     }
 
     @Test
-   // @Repeat(value = 1000)
+    @Repeat(value = 1000)
     public void testExecuteQuery(TestContext context) throws Exception {
         int numDocs = 100;
         for (int i = 0; i < numDocs; i++) {

--- a/src/test/java/io/mewbase/QueryTest.java
+++ b/src/test/java/io/mewbase/QueryTest.java
@@ -5,6 +5,7 @@ import io.mewbase.client.MewException;
 import io.mewbase.client.Producer;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.Repeat;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -64,6 +65,7 @@ public class QueryTest extends ServerTestBase {
         }
     }
 
+    @Repeat(value=1000)
     @Test
     public void testExecuteQuery(TestContext context) throws Exception {
         int numDocs = 100;

--- a/src/test/java/io/mewbase/QueryTest.java
+++ b/src/test/java/io/mewbase/QueryTest.java
@@ -66,7 +66,7 @@ public class QueryTest extends ServerTestBase {
     }
 
     @Test
-    @Repeat(value = 1000)
+    //@Repeat(value = 1000)
     public void testExecuteQuery(TestContext context) throws Exception {
         int numDocs = 100;
         for (int i = 0; i < numDocs; i++) {

--- a/src/test/java/io/mewbase/QueryTest.java
+++ b/src/test/java/io/mewbase/QueryTest.java
@@ -66,6 +66,7 @@ public class QueryTest extends ServerTestBase {
     }
 
     @Test
+   // @Repeat(value = 1000)
     public void testExecuteQuery(TestContext context) throws Exception {
         int numDocs = 100;
         for (int i = 0; i < numDocs; i++) {

--- a/src/test/java/io/mewbase/QueryTest.java
+++ b/src/test/java/io/mewbase/QueryTest.java
@@ -83,8 +83,8 @@ public class QueryTest extends ServerTestBase {
         Async async = context.async();
         AtomicInteger cnt = new AtomicInteger();
         client.executeQuery("testQuery", new BsonObject(), qr -> {
-            //String expectedID = getID(cnt.getAndIncrement());
-            //context.assertEquals(expectedID, qr.document().getString("id"));
+            String expectedID = getID(cnt.getAndIncrement());
+            context.assertEquals(expectedID, qr.document().getString("id"));
             cnt.getAndIncrement();
             if (cnt.get() == numDocs) {
                 context.assertTrue(qr.isLast());

--- a/src/test/java/io/mewbase/log/PublishObjectsTest.java
+++ b/src/test/java/io/mewbase/log/PublishObjectsTest.java
@@ -119,7 +119,7 @@ public class PublishObjectsTest extends LogTestBase {
         startLog();
         List<Long> orderedResults = publishObjectsConcurrently(numRecords, i -> event.copy().put("num", i));
 
-        // Wait until the logs are flushed to avoid incomlpete read below
+        // Wait until the logs are flushed to avoid incomplete read below
         Thread.sleep(11);
 
         assertExists(0);

--- a/src/test/java/io/mewbase/log/PublishObjectsTest.java
+++ b/src/test/java/io/mewbase/log/PublishObjectsTest.java
@@ -120,7 +120,7 @@ public class PublishObjectsTest extends LogTestBase {
         List<Long> orderedResults = publishObjectsConcurrently(numRecords, i -> event.copy().put("num", i));
 
         // Wait until the logs are flushed to avoid incomplete read below
-        Thread.sleep(11);
+        Thread.sleep(100);
 
         assertExists(0);
         assertLogChunkLength(0, expChunkLength);

--- a/src/test/java/io/mewbase/util/PoolTest.java
+++ b/src/test/java/io/mewbase/util/PoolTest.java
@@ -1,0 +1,91 @@
+/*
+ *
+ *  Copyright 2014 Red Hat, Inc.
+ *
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  and Apache License v2.0 which accompanies this distribution.
+ *
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
+ *
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
+ *
+ *  You may elect to redistribute this code under either of these licenses.
+ *
+ *
+ */
+
+package io.mewbase.util;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.WorkerExecutor;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static junit.framework.Assert.assertNotSame;
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertNotNull;
+import static junit.framework.TestCase.fail;
+
+/**
+ * @author Nige
+ */
+@RunWith(VertxUnitRunner.class)
+public class PoolTest {
+
+    private final Vertx vertx = Vertx.vertx();
+    private final String POOL_NAME = "TestPool";
+
+    @Test
+    public void failsForNonsensicalPoolSize() throws Exception {
+        try {
+            SizedExecutorPool pool = new SizedExecutorPool(vertx, POOL_NAME, 0);
+            fail("Should not be able to create pool with size less then 1");
+        } catch (AssertionError error){
+        }
+    }
+
+
+    @Test
+    public void poolCreatesSingleWorker() throws Exception {
+        final int size = 1;
+        SizedExecutorPool pool = new SizedExecutorPool(vertx,POOL_NAME,size);
+        WorkerExecutor exec1 = pool.getWorkerExecutor();
+        assertNotNull(exec1);
+        WorkerExecutor exec2 = pool.getWorkerExecutor();
+        assertEquals(exec1,exec2);
+    }
+
+    @Test
+    public void poolCreatesManyWorkers() throws Exception {
+        final int size = 3;
+        SizedExecutorPool pool = new SizedExecutorPool(vertx,POOL_NAME,size);
+        WorkerExecutor exec1 = pool.getWorkerExecutor();
+        assertNotNull(exec1);
+        WorkerExecutor exec2 = pool.getWorkerExecutor();
+        assertNotNull(exec2);
+        WorkerExecutor exec3 = pool.getWorkerExecutor();
+        assertNotNull(exec3);
+
+        assertNotSame(exec1,exec2);
+        assertNotSame(exec2,exec3);
+        assertNotSame(exec3,exec1);
+
+        // check we have wrapped around
+        WorkerExecutor exec4 = pool.getWorkerExecutor();
+        assertEquals(exec1,exec4);
+
+        // check others wrap
+        WorkerExecutor exec5 = pool.getWorkerExecutor();
+        assertEquals(exec2,exec5);
+        WorkerExecutor exec6 = pool.getWorkerExecutor();
+        assertEquals(exec3,exec6);
+
+        // double wrap
+        WorkerExecutor exec7 = pool.getWorkerExecutor();
+        assertEquals(exec7,exec4); // and 4 ==1 already
+    }
+}


### PR DESCRIPTION
This ports the Binders implementation from LMDBjni to LMDBjava.

LMDBjava reported running out of readers associated with read txns. 

Upped reader count to 1024 and all test pass locally.

Added and commented out some instrumentation (global static counter) for open read txns. 

Also may make many off stack byte arrays which could lead to memory exhaustion in a long running server. Needs some soak testing.