### PR TITLE
Correct Wire protocol description 

### DIFF
--- a/src/main/java/io/mewbase/server/impl/cqrs/QueryImpl.java
+++ b/src/main/java/io/mewbase/server/impl/cqrs/QueryImpl.java
@@ -8,6 +8,7 @@ import io.mewbase.server.QueryContext;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
+
 /**
  * Created by tim on 10/01/17.
  */

--- a/wire_protocol.md
+++ b/wire_protocol.md
@@ -179,8 +179,8 @@ Sent by client to query documents from a binder
 Fields
  
 * `queryID` - mandatory, int32. Unique id of query per connection.
-* `binder` - mandatory, string. Name of binder to query in.
-* `matcher` - mandatory, BSONObject. Matcher to match documents in binder.
+* `name` - mandatory, string that unique names the Query
+* `params` - mandatory, BSONObject. Parameters that provide a context to the Query Function defined in the server.
 
 The server will respond with a QUERYRESPONSE after processing the query request.
 


### PR DESCRIPTION
Wire protocol description was misleading. Corrected wire-protocol.md to reflect changed use of Bson params in line with implementation.