### PR TITLE
lmdb windows bug fixed

### DIFF
--- a/src/main/java/io/mewbase/binders/impl/lmdb/LmdbBinderStore.java
+++ b/src/main/java/io/mewbase/binders/impl/lmdb/LmdbBinderStore.java
@@ -127,9 +127,11 @@ public class LmdbBinderStore implements BinderStore {
     public CompletableFuture<Boolean> close() {
         AsyncResCF<Boolean> res = new AsyncResCF<>();
         exec.executeBlocking(fut -> {
-            Set<CompletableFuture<Void>> all = binders().map(binder -> ((LmdbBinder)binder).close()).collect(Collectors.toSet());
+            //Set<CompletableFuture<Void>> all = binders().map(binder -> ((LmdbBinder)binder).close()).collect(Collectors.toSet());
             try {
-                CompletableFuture.allOf(all.toArray(new CompletableFuture[all.size()])).get();
+               // CompletableFuture.allOf(all.toArray(new CompletableFuture[all.size()])).get();
+                Stream<CompletableFuture<Void>> all = binders().map(binder -> ((LmdbBinder)binder).close());
+
             } catch (Exception e) {
                 logger.error("Failed to close all binders.", e);
             } finally {

--- a/src/main/java/io/mewbase/server/MewbaseOptions.java
+++ b/src/main/java/io/mewbase/server/MewbaseOptions.java
@@ -35,7 +35,7 @@ public class MewbaseOptions {
 
     // Binders
     public static final String DEFAULT_BINDERS_DIR = "mewdata/binders";
-    public static final long DEFAULT_MAX_BINDER_SIZE = 1024L * 1024L * 1024L * 1024L; // 1 Terabyte
+    public static final long DEFAULT_MAX_BINDER_SIZE = 1024L * 1024L * 1024L; //1 Gigabyte // * 1024L; // 1 Terabyte
     public static final int DEFAULT_MAX_BINDERS = 256;
 
 

--- a/src/main/java/io/mewbase/server/impl/ServerImpl.java
+++ b/src/main/java/io/mewbase/server/impl/ServerImpl.java
@@ -74,6 +74,7 @@ public class ServerImpl implements Server {
 
     @Override
     public synchronized CompletableFuture<Void> stop() {
+        this.binderStore.close();
         CompletableFuture<Void> cf = restServiceAdaptor.stop();
         if (ownVertx) {
             cf = cf.thenCompose(v -> {

--- a/src/test/java/io/mewbase/MewbaseTestBase.java
+++ b/src/test/java/io/mewbase/MewbaseTestBase.java
@@ -1,7 +1,9 @@
 package io.mewbase;
 
 import io.mewbase.server.MewbaseOptions;
+import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.RepeatRule;
+import org.junit.After;
 import org.junit.Rule;
 import org.junit.rules.TemporaryFolder;
 
@@ -21,6 +23,11 @@ public class MewbaseTestBase {
 
     @Rule
     public RepeatRule repeatRule = new RepeatRule();
+
+    @After
+    public void after(TestContext context) throws Exception {
+        Thread.sleep(500);
+    }
 
 
     protected void waitUntil(BooleanSupplier supplier) {

--- a/src/test/java/io/mewbase/binder/BindersTest.java
+++ b/src/test/java/io/mewbase/binder/BindersTest.java
@@ -80,6 +80,7 @@ public class BindersTest extends MewbaseTestBase {
        assertNull(binder.put("id1234", docPut).get());
        BsonObject docGet = binder.get("id1234").get();
        assertEquals(docPut, docGet);
+       store.close();
     }
 
     @Test
@@ -87,6 +88,7 @@ public class BindersTest extends MewbaseTestBase {
         BinderStore store = new LmdbBinderStore(createMewbaseOptions());
         Binder binder = store.open(BINDER_NAME).get();
         assertNull(binder.get("id1234").get());
+        store.close();
     }
 
     @Test
@@ -101,6 +103,7 @@ public class BindersTest extends MewbaseTestBase {
         assertTrue(binder.delete("id1234").get());
         docGet = binder.get("id1234").get();
         assertNull(docGet);
+        store.close();
     }
 
 
@@ -146,7 +149,7 @@ public class BindersTest extends MewbaseTestBase {
         }).get();
 
         assertEquals(some.collect(toSet()).size(), HALF_THE_DOCS);
-
+        store.close();
     }
 
 
@@ -172,7 +175,7 @@ public class BindersTest extends MewbaseTestBase {
 
         BsonObject docGet2 = binder2.get("id0").get();
         assertEquals("binder2", docGet2.remove("binder"));
-
+        store.close();
     }
 
     @Test


### PR DESCRIPTION
The problem with windows and lmdbjava is described in the following issue about lmdbjava:

https://github.com/lmdbjava/lmdbjava/issues/68

I tried to use the lmdbjava-0.9.21.1 but it didn't work. So one of the changes necessary for this to work in windows is to change the maxDBsize from 1TB to 1GB, or to a smaller size than the computer disk.

Another problem with windows was the fact that the test weren't deleting the Temporary Folders and this was filling up the disk. Main cause was the fact that not all connections were being closed. Except the Binders Test which were blocking in LMDBBinderStore.Close() and the tests never closed their connections. 

I tested these changes in Windows and Mac. They seem to be working ok. 