### PR TITLE
Event Based Examples

### DIFF
--- a/src/example/java/io/mewbase/example/shopping/FridgeExample.java
+++ b/src/example/java/io/mewbase/example/shopping/FridgeExample.java
@@ -4,17 +4,15 @@ import io.mewbase.binders.Binder;
 import io.mewbase.binders.BinderStore;
 import io.mewbase.binders.impl.lmdb.LmdbBinderStore;
 import io.mewbase.bson.BsonObject;
-import io.mewbase.bson.BsonPath;
 
 import io.mewbase.eventsource.Event;
 import io.mewbase.eventsource.EventSink;
 import io.mewbase.eventsource.EventSource;
 import io.mewbase.eventsource.impl.nats.NatsEventSink;
 import io.mewbase.eventsource.impl.nats.NatsEventSource;
-import io.mewbase.projection.ProjectionBuilder;
+
 import io.mewbase.projection.ProjectionManager;
-import io.mewbase.server.Server;
-import io.mewbase.server.MewbaseOptions;
+
 
 import java.util.function.Consumer;
 
@@ -44,8 +42,8 @@ public class FridgeExample {
 
     public static void main(String[] args) throws Exception {
 
-        // In order to run a projection Setup a projection that will run
-        // when new events arrive start an EventSource and BinderStore.
+
+        // In order to run a projection set up an EventSource and BinderStore.
         EventSource src = new NatsEventSource();
         BinderStore store = new LmdbBinderStore();
         ProjectionManager mgr = ProjectionManager.instance(src,store);
@@ -73,6 +71,9 @@ public class FridgeExample {
                 .create();
 
 
+
+        //************************** Client Side Setup ******************************
+
         // set up a sink to send events to the projection
         EventSink sink = new NatsEventSink();
 
@@ -80,9 +81,9 @@ public class FridgeExample {
         BsonObject event = new BsonObject().put("fridgeID", "f1").put("eventType", "doorStatus");
         sink.publish(FRIDGE_EVENT_CHANNEL_NAME, event.copy().put("status", "open"));
 
-        Thread.sleep(10);
+        Thread.sleep(100);
 
-        // Now get the status
+        // Consumer of the Docuemnt
         Consumer<BsonObject> statusDocumentConsumer = fridgeStateDoc ->
                 System.out.println("Fridge State is :" + fridgeStateDoc);
 
@@ -91,7 +92,7 @@ public class FridgeExample {
 
         // Shut that door
         sink.publish(FRIDGE_EVENT_CHANNEL_NAME,event.copy().put("status", "shut"));
-        Thread.sleep(10);
+        Thread.sleep(100);
 
         // Now get the fridge state again
         fridgeStatusBinder.get("f1").thenAccept( statusDocumentConsumer );

--- a/src/example/java/io/mewbase/example/shopping/ShoppingBasketExample.java
+++ b/src/example/java/io/mewbase/example/shopping/ShoppingBasketExample.java
@@ -1,72 +1,107 @@
 package io.mewbase.example.shopping;
 
+import io.mewbase.binders.Binder;
+import io.mewbase.binders.BinderStore;
+import io.mewbase.binders.impl.lmdb.LmdbBinderStore;
 import io.mewbase.bson.BsonObject;
 import io.mewbase.bson.BsonPath;
 
+import io.mewbase.eventsource.Event;
+import io.mewbase.eventsource.EventSink;
+import io.mewbase.eventsource.EventSource;
+import io.mewbase.eventsource.impl.nats.NatsEventSink;
+import io.mewbase.eventsource.impl.nats.NatsEventSource;
+import io.mewbase.projection.ProjectionManager;
 import io.mewbase.server.Server;
 import io.mewbase.server.MewbaseOptions;
 
+import java.util.function.Consumer;
+
 /**
+ * Simple Shopping Basket when the Basket is an Aggregate projection over the
+ * order events
+ *
+
  * Created by tim on 08/11/16.
+ * Updated by Nige on 25/10/17
  */
+
 public class ShoppingBasketExample {
 
-    public static void main(String[] args) {
-        try {
-            new ShoppingBasketExample().example();
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-        System.out.println("Main complete");
-    }
 
-    /*
-    Simple shopping basket example
-     */
-    private void example() throws Exception {
+    public static void main(String[] args) throws Exception {
 
-        // Setup and start a server
-        MewbaseOptions options = new MewbaseOptions();
+        // In order to run a projection set up an EventSource and BinderStore.
+        EventSource src = new NatsEventSource();
+        BinderStore store = new LmdbBinderStore();
+        ProjectionManager mgr = ProjectionManager.instance(src,store);
 
-//        Server server = Server.newServer(options);
-//        server.start().get();
+        final String ORDERS_EVENT_CHANNEL = "OrderEventsChannel";
+        final String BASKETS_BINDER_NAME = "Baskets";
+        final String PROJECTION_NAME = "MaintainBasket";
 
-//        server.createBinder("baskets").get();
-//
-//        // TODO - replace when we work out how to do this with the abstracted channels
-//        // server.createChannel("orders").get();
-//
-//        // Register a projection that will respond to add_item events and increase/decrease the quantity of the item in the basket
-//        server.buildProjection("maintain_basket")                             // projection name
-//                .projecting("orders")                                           // channel name
-//                .filteredBy(ev -> ev.getString("eventType").equals("add_item")) // event filter
-//                .onto("baskets")                                                // binder name
-//                .identifiedBy(ev -> ev.getString("basketID"))                   // document id selector; how to obtain the doc id from the event bson
-//                .as((basket, event) -> // projection function
-//                        BsonPath.add(basket, event.getInteger("quantity"), "products", event.getString("productID")))
-//                .create();
+        final String EVENT_TYPE_KEY = "EventType";
+        final String ADD_EVENT = "AddEvent";
+        final String REMOVE_EVENT = "RemoveEvent";
 
-        // Create a client
-        //Client client = Client.newClient(new ClientOptions());
+        final String BASKET_ID_KEY = "BasketID";
+        final String BASKET_ID = "Basket-i834582267567568947";
 
-        // Send some add/remove events
+        // Register a projection that will respond to add_item events and increase/decrease the
+        // quantity of the item in the basket
+        mgr.builder().named(PROJECTION_NAME)
+                        // Channel to listen to
+                        .projecting(ORDERS_EVENT_CHANNEL)
+                        // filter for the addItem events
+                        .filteredBy(evt -> {
+                            final String eventType =  evt.getBson().getString(EVENT_TYPE_KEY);
+                            return eventType.equals(ADD_EVENT) || eventType.equals(REMOVE_EVENT);
+                        })
+                        // event filter
+                        .onto(BASKETS_BINDER_NAME)
+                        // find the Basket in the binder
+                        .identifiedBy(evt -> evt.getBson().getString(BASKET_ID_KEY))
+                        // projection
+                        .as( (BsonObject basket, Event evt) ->  {
+                            final String eventType = evt.getBson().getString(EVENT_TYPE_KEY);
+                            final String productID = evt.getBson().getString("productID");
+                            final int quantity = evt.getBson().getInteger("quantity");
 
-        BsonObject event = new BsonObject().put("eventType", "add_item").put("basketID", "basket1111");
+                            // get the current quantity from the basket
+                            final Integer prevQuantity = basket.getInteger(productID,0);
+                            if (eventType.equals(ADD_EVENT)) basket.put(productID,prevQuantity+quantity);
+                            if (eventType.equals(REMOVE_EVENT)) basket.put(productID,prevQuantity-quantity);
+                            return basket;
+                        } ).create();
 
-        // TODO with new Streaming Server
-       // client.publish("orders", event.copy().put("productID", "prod1234").put("quantity", 2));
-       // client.publish("orders", event.copy().put("productID", "prod2341").put("quantity", 1));
-       // client.publish("orders", event.copy().put("productID", "prod5432").put("quantity", 3));
-       // client.publish("orders", event.copy().put("productID", "prod5432").put("quantity", -1));
 
-        Thread.sleep(1000);
+        //************************** Client Side Setup ******************************
 
-        // Now get the basket
-       // BsonObject basket = client.findByID("baskets", "basket1111").get();
+        // set up a sink to send events to the projection
+        EventSink sink = new NatsEventSink();
 
-       // System.out.println("Basket is: " + basket);
+        // Create some add/remove events
+        BsonObject event = new BsonObject().put(BASKET_ID_KEY, BASKET_ID);
+        BsonObject addEvent = event.copy().put(EVENT_TYPE_KEY, ADD_EVENT);
+        BsonObject remEvent = event.copy().put(EVENT_TYPE_KEY, REMOVE_EVENT);
 
-       // client.close().get();
-       // server.stop().get();
+        sink.publish(ORDERS_EVENT_CHANNEL, addEvent.copy().put("productID", "prod1234").put("quantity", 2));
+        sink.publish(ORDERS_EVENT_CHANNEL, addEvent.copy().put("productID", "prod2341").put("quantity", 1));
+        sink.publish(ORDERS_EVENT_CHANNEL, addEvent.copy().put("productID", "prod5432").put("quantity", 3));
+        sink.publish(ORDERS_EVENT_CHANNEL, remEvent.copy().put("productID", "prod5432").put("quantity", 1));
+
+        Thread.sleep(100);
+
+        // Consumer of the Basket
+        Consumer<BsonObject> basketConsumer = basketState ->
+                System.out.println("Basket State is :" + basketState);
+
+        Binder fridgeStatusBinder = store.get(BASKETS_BINDER_NAME).get();
+        fridgeStatusBinder.get(BASKET_ID).thenAccept( basketConsumer );
+
+        // close the resources
+        sink.close();
+        src.close();
+        store.close();
     }
 }

--- a/src/example/java/io/mewbase/example/shopping/ShoppingBasketExample.java
+++ b/src/example/java/io/mewbase/example/shopping/ShoppingBasketExample.java
@@ -21,7 +21,6 @@ import java.util.function.Consumer;
  * Simple Shopping Basket when the Basket is an Aggregate projection over the
  * order events
  *
-
  * Created by tim on 08/11/16.
  * Updated by Nige on 25/10/17
  */

--- a/src/main/java/io/mewbase/binders/BinderStore.java
+++ b/src/main/java/io/mewbase/binders/BinderStore.java
@@ -56,6 +56,6 @@ public interface BinderStore {
      *
      * @return
      */
-    Boolean close();
+    Boolean close() throws Exception;
 
 }

--- a/src/main/java/io/mewbase/binders/impl/lmdb/LmdbBinder.java
+++ b/src/main/java/io/mewbase/binders/impl/lmdb/LmdbBinder.java
@@ -59,44 +59,6 @@ public class LmdbBinder implements Binder {
         return name;
     }
 
-//    @Override
-//    public CompletableFuture<Stream<String>> getIds() {
-//        return getIdsWithFilter(b -> true);
-//    }
-//
-//    @Override
-//    public CompletableFuture<Stream<String>> getIdsWithFilter(Predicate<BsonObject> filter) {
-//
-//       CompletableFuture fut = CompletableFuture.supplyAsync( () -> {
-//
-//            LinkedList<String> matchingIds = new LinkedList<String>();
-//
-//            try (final Txn<ByteBuffer> txn = env.txnRead()) {
-//                final CursorIterator<ByteBuffer> cursorItr = dbi.iterate(txn, FORWARD);
-//                final Iterator<CursorIterator.KeyVal<ByteBuffer>> itr = cursorItr.iterable().iterator();
-//                boolean hasNext = itr.hasNext();
-//                txn.reset();
-//
-//                while (hasNext) {
-//                    txn.renew();
-//                    final CursorIterator.KeyVal<ByteBuffer> kv = itr.next();
-//                    // Copy bytes from LMDB managed memory to vert.x buffers
-//                    final Buffer keyBuffer = Buffer.buffer(kv.key().remaining());
-//                    keyBuffer.setBytes(0, kv.key());
-//                    final Buffer valueBuffer = Buffer.buffer(kv.val().remaining());
-//                    valueBuffer.setBytes(0, kv.val());
-//                    hasNext = itr.hasNext(); // iterator makes reference to the txn
-//                    txn.reset(); // got data so release the txn
-//                    final BsonObject doc = new BsonObject(valueBuffer);
-//                    final String docId = new String(keyBuffer.getBytes());
-//                    if (filter.test(doc)) matchingIds.addLast(docId);
-//                }
-//            }
-//            return matchingIds.stream();
-//        }, stexec);
-//        return fut;
-//    }
-
 
     @Override
     public CompletableFuture<BsonObject> get(String id) {
@@ -188,7 +150,7 @@ public class LmdbBinder implements Binder {
         return fut.join().stream();
     }
 
-
+    
     public Void close() {
         env.sync(true);
         dbi.close();

--- a/src/main/java/io/mewbase/binders/impl/lmdb/LmdbBinderStore.java
+++ b/src/main/java/io/mewbase/binders/impl/lmdb/LmdbBinderStore.java
@@ -97,7 +97,7 @@ public class LmdbBinderStore implements BinderStore {
     @Override
     public Boolean close() {
         try {
-            binders().map(binder -> ((LmdbBinder)binder).close());
+            binders().forEach(binder -> ((LmdbBinder)binder).close());
         } catch (Exception e) {
             logger.error("Failed to close all binders.", e);
         } finally {

--- a/src/main/java/io/mewbase/projection/impl/ProjectionManagerImpl.java
+++ b/src/main/java/io/mewbase/projection/impl/ProjectionManagerImpl.java
@@ -29,7 +29,7 @@ public class ProjectionManagerImpl implements ProjectionManager {
     private final EventSource source;
     private final BinderStore store;
 
-    final String PROJ_STATE_BINDER_NAME = "_mewbase.proj.state";
+    final String PROJ_STATE_BINDER_NAME = "mewbase.proj.state";
     final String EVENT_NUM_FIELD = "eventNum";
     private final Binder stateBinder;
 

--- a/src/main/java/io/mewbase/server/impl/ServerImpl.java
+++ b/src/main/java/io/mewbase/server/impl/ServerImpl.java
@@ -66,7 +66,7 @@ public class ServerImpl implements Server {
 
 
     public synchronized CompletableFuture<Void> stop() {
-        this.binderStore.close();
+       // this.binderStore.close();
         CompletableFuture<Void> cf = restServiceAdaptor.stop();
         if (ownVertx) {
             cf = cf.thenCompose(v -> {


### PR DESCRIPTION
Updates the two event based shopping examples to the Serverless "library" refactoring of the toolkit.
Also fixes "long running threads" in Binders Issue, meaning that tests and example halt immediately on closing the BinderStore.
