### PR TITLE
Postgres Binders

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <version>42.1.4</version>
+        </dependency>
+
+        <dependency>
             <groupId>io.nats</groupId>
             <artifactId>java-nats-streaming</artifactId>
             <version>0.4.1</version>

--- a/src/main/java/io/mewbase/binders/BinderStore.java
+++ b/src/main/java/io/mewbase/binders/BinderStore.java
@@ -2,6 +2,7 @@ package io.mewbase.binders;
 
 
 import io.mewbase.binders.impl.filestore.FileBinderStore;
+import io.mewbase.binders.impl.postgres.PostgresBinderStore;
 import io.mewbase.eventsource.EventSource;
 import io.mewbase.projection.ProjectionManager;
 import io.mewbase.projection.impl.ProjectionManagerImpl;
@@ -18,7 +19,7 @@ public interface BinderStore {
 
 
     static BinderStore instance(MewbaseOptions opts) {
-        return new FileBinderStore(opts);
+        return new PostgresBinderStore(opts);
     }
 
     static BinderStore instance() {

--- a/src/main/java/io/mewbase/binders/BinderStore.java
+++ b/src/main/java/io/mewbase/binders/BinderStore.java
@@ -19,7 +19,7 @@ public interface BinderStore {
 
 
     static BinderStore instance(MewbaseOptions opts) {
-        return new PostgresBinderStore(opts);
+        return new FileBinderStore(opts);
     }
 
     static BinderStore instance() {

--- a/src/main/java/io/mewbase/binders/BinderStore.java
+++ b/src/main/java/io/mewbase/binders/BinderStore.java
@@ -65,6 +65,7 @@ public interface BinderStore {
      * @param  name of  binder
      * @return a CompleteableFuture with a Boolean set to true if successful
      */
+    @Deprecated
     Boolean delete(String name);
 
 

--- a/src/main/java/io/mewbase/binders/impl/postgres/PostgresBinder.java
+++ b/src/main/java/io/mewbase/binders/impl/postgres/PostgresBinder.java
@@ -39,7 +39,7 @@ public class PostgresBinder implements Binder {
         this.name = name;
         try {
             createIfDoesntExists(name);
-            log.trace("Opened Binder named " + name);
+            log.info("Opened Binder named " + name);
         } catch (Exception exp) {
             log.error("Failed to open binder " + name, exp);
         }
@@ -144,7 +144,7 @@ public class PostgresBinder implements Binder {
                     }
                 }
             } catch (Exception ex) {
-                log.error("File based Binder failed to start", ex);
+                log.error("Postgres Binder failed to get documents", ex);
             }
             return resultSet;
         }, stexec);
@@ -153,8 +153,11 @@ public class PostgresBinder implements Binder {
 
 
     public void createIfDoesntExists(final String name) throws SQLException {
-        final String sql = "CREATE TABLE IF NOT EXISTS "+name+" (key TEXT, data bytea, PRIMARY KEY ( key ))";
-        connection.createStatement().executeUpdate(sql);
+        final String schemaSql = "CREATE SCHEMA IF NOT EXISTS mewbase;";
+        connection.createStatement().executeUpdate(schemaSql);
+        final String tableSql =  "CREATE TABLE IF NOT EXISTS mewbase."+ name +
+                                    " (key TEXT, data bytea, PRIMARY KEY ( key ))";
+        connection.createStatement().executeUpdate(tableSql);
     }
 
 }

--- a/src/main/java/io/mewbase/binders/impl/postgres/PostgresBinder.java
+++ b/src/main/java/io/mewbase/binders/impl/postgres/PostgresBinder.java
@@ -63,8 +63,10 @@ public class PostgresBinder implements Binder {
                 if (resultSet.next()) {
                     byte[] buffer = resultSet.getBytes("data");
                     doc = new BsonObject(buffer);
-                    resultSet.close();
+
                 }
+                resultSet.close();
+                stmt.close();
             } catch (Exception exp) {
                     log.error("Error getting document with key : " + id);
                     throw new CompletionException(exp);
@@ -100,6 +102,7 @@ public class PostgresBinder implements Binder {
 
 
     @Override
+    @Deprecated
     public CompletableFuture<Boolean> delete(final String id) {
 
         CompletableFuture fut = CompletableFuture.supplyAsync( () -> {
@@ -143,6 +146,9 @@ public class PostgresBinder implements Binder {
                         }
                     }
                 }
+                dbrs.close();
+                stmt.close();
+
             } catch (Exception ex) {
                 log.error("Postgres Binder failed to get documents", ex);
             }

--- a/src/main/java/io/mewbase/binders/impl/postgres/PostgresBinder.java
+++ b/src/main/java/io/mewbase/binders/impl/postgres/PostgresBinder.java
@@ -1,0 +1,157 @@
+package io.mewbase.binders.impl.postgres;
+
+
+import io.mewbase.binders.Binder;
+import io.mewbase.binders.KeyVal;
+import io.mewbase.bson.BsonObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+import java.sql.*;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+
+
+/**
+ * Created by Nige on 4/12/17.
+ */
+public class PostgresBinder implements Binder {
+
+    private final static Logger log = LoggerFactory.getLogger(PostgresBinder.class);
+
+    private final String name;
+
+    private final ExecutorService stexec = Executors.newSingleThreadExecutor();
+
+    private final Connection connection;
+
+
+    public PostgresBinder(Connection connection, String name) {
+        this.connection = connection;
+        this.name = name;
+        try {
+            createIfDoesntExists(name);
+            log.trace("Opened Binder named " + name);
+        } catch (Exception exp) {
+            log.error("Failed to open binder " + name, exp);
+        }
+    }
+
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+
+    @Override
+    public CompletableFuture<BsonObject> get(final String id) {
+
+        CompletableFuture fut = CompletableFuture.supplyAsync( () -> {
+            BsonObject doc = null;
+            try {
+                final Statement stmt = connection.createStatement();
+                final ResultSet resultSet = stmt.executeQuery("SELECT data FROM "+name+" WHERE key = '"+id+"';");
+                if (resultSet.first()) {
+                    byte[] buffer = resultSet.getBytes("data");
+                    doc = new BsonObject(buffer);
+                    resultSet.close();
+                }
+            } catch (Exception exp) {
+                    log.error("Error getting document with key : " + id);
+                    throw new CompletionException(exp);
+            }
+            return doc;
+        }, stexec);
+        return fut;
+    }
+
+
+    @Override
+    public CompletableFuture<Void> put(final String id, final BsonObject doc) {
+
+        final byte[] valBytes = doc.encode().getBytes();
+
+        CompletableFuture fut = CompletableFuture.runAsync( () -> {
+            try {
+                final PreparedStatement stmt = connection.prepareStatement("INSERT INTO "+name+" VALUES(?,?)");
+                stmt.setString(1,id);
+                stmt.setBytes(2,valBytes);
+                stmt.executeUpdate();
+                stmt.close();
+            } catch (Exception exp) {
+                log.error("Error writing document key : " + id + " value : " + doc);
+                throw new CompletionException(exp);
+            }
+        }, stexec);
+        return fut;
+    }
+
+
+    @Override
+    public CompletableFuture<Boolean> delete(final String id) {
+
+        CompletableFuture fut = CompletableFuture.supplyAsync( () -> {
+            try {
+                final Statement stmt = connection.createStatement();
+                stmt.executeUpdate("DELETE FROM "+name+" WHERE key = '"+id+"';");
+                stmt.close();
+                return true;
+            } catch (Exception exp) {
+                log.error("Error deleting document " + id );
+                throw new CompletionException(exp);
+            }
+        }, stexec);
+        return fut;
+    }
+
+
+    @Override
+    public Stream<KeyVal<String, BsonObject>> getDocuments() {
+        return getDocuments( new HashSet(), document -> true);
+    }
+
+
+    @Override
+    public Stream<KeyVal<String, BsonObject>> getDocuments(Set<String> keySet, Predicate<BsonObject> filter) {
+        CompletableFuture<Set<KeyVal<String, BsonObject>>> fut = CompletableFuture.supplyAsync( () -> {
+
+            Set<KeyVal<String, BsonObject>> resultSet = new HashSet<>();
+
+            try {
+                final Statement stmt = connection.createStatement();
+                final ResultSet dbrs = stmt.executeQuery("SELECT key, data from "+name+";");
+                while(dbrs.next()) {
+                    final String key = dbrs.getString("key");
+                    if (keySet.isEmpty() || keySet.contains(key)) {
+                        byte[] bytes = dbrs.getBytes("data");
+                        final BsonObject doc = new BsonObject(bytes);
+                        if (filter.test(doc)) {
+                            KeyVal<String,BsonObject> kv = KeyVal.create(key, doc);
+                            resultSet.add(kv);
+                        }
+                    }
+                }
+            } catch (Exception ex) {
+                log.error("File based Binder failed to start", ex);
+            }
+            return resultSet;
+        }, stexec);
+        return fut.join().stream();
+    }
+
+
+    public void createIfDoesntExists(final String name) throws SQLException {
+        final String sql = "CREATE TABLE IF NOT EXISTS "+name+" (key TEXT, data BLOB, PRIMARY KEY ( key ))";
+        connection.createStatement().executeUpdate(sql);
+    }
+
+}

--- a/src/main/java/io/mewbase/binders/impl/postgres/PostgresBinderStore.java
+++ b/src/main/java/io/mewbase/binders/impl/postgres/PostgresBinderStore.java
@@ -15,7 +15,11 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.sql.Connection;
 import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.util.HashSet;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.stream.Stream;
@@ -43,9 +47,7 @@ public class PostgresBinderStore implements BinderStore {
             logger.error("Postgres binder failed to start", exp);
         }
 
-
-        // list all dbs <=>  binders
-        // then  open(binder name);
+        listAllTables().forEach( name -> open(name) );
     }
 
 
@@ -74,6 +76,24 @@ public class PostgresBinderStore implements BinderStore {
     public Boolean delete(String name) {
         return null;
     }
+
+
+    private Stream<String> listAllTables() {
+        Set<String> names = new HashSet();
+        try {
+            final String sql = "SELECT * FROM pg_catalog.pg_tables WHERE schemaname = 'mewbase';";
+            final Statement stmt = connection.createStatement();
+            final ResultSet dbrs = stmt.executeQuery(sql);
+
+            while (dbrs.next()) {
+                names.add(dbrs.getString(2));
+            }
+        } catch (Exception exp) {
+            logger.error("Failed to find current binders list in postgres",exp);
+        }
+        return names.stream();
+    }
+
 
 
 }

--- a/src/main/java/io/mewbase/binders/impl/postgres/PostgresBinderStore.java
+++ b/src/main/java/io/mewbase/binders/impl/postgres/PostgresBinderStore.java
@@ -1,0 +1,79 @@
+package io.mewbase.binders.impl.postgres;
+
+
+import io.mewbase.binders.Binder;
+import io.mewbase.binders.BinderStore;
+import io.mewbase.binders.impl.filestore.FileBinder;
+import io.mewbase.server.MewbaseOptions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.stream.Stream;
+
+
+public class PostgresBinderStore implements BinderStore {
+
+    private final static Logger logger = LoggerFactory.getLogger(PostgresBinderStore.class);
+
+    protected final ConcurrentMap<String, Binder> binders = new ConcurrentHashMap<>();
+
+    Connection connection;
+
+
+    public PostgresBinderStore() { this(new MewbaseOptions()); }
+
+    public PostgresBinderStore(MewbaseOptions mewbaseOptions) {
+
+        try {
+            Class.forName("org.postgresql.Driver");
+            final String uri = "jdbc:postgresql://127.0.0.1:5432/mewbase";
+            connection = DriverManager.getConnection(uri, "mewbase", "mewbase");
+            logger.info("Started postgress binder store with  " + uri);
+        } catch (Exception exp) {
+            logger.error("Postgres binder failed to start", exp);
+        }
+
+
+        // list all dbs <=>  binders
+        // then  open(binder name);
+    }
+
+
+    @Override
+    public Binder open(String name) {
+        return binders.computeIfAbsent(name, key -> new PostgresBinder(connection, key));
+    }
+
+    @Override
+    public Optional<Binder> get(String name) {
+        return Optional.ofNullable(binders.get(name));
+    }
+
+    @Override
+    public Stream<Binder> binders() {
+        return binders.values().stream();
+    }
+
+    @Override
+    public Stream<String> binderNames() {
+        return binders.keySet().stream();
+    }
+
+
+    @Override
+    public Boolean delete(String name) {
+        return null;
+    }
+
+
+}

--- a/src/main/java/io/mewbase/binders/impl/postgres/PostgresBinderStore.java
+++ b/src/main/java/io/mewbase/binders/impl/postgres/PostgresBinderStore.java
@@ -88,6 +88,8 @@ public class PostgresBinderStore implements BinderStore {
             while (dbrs.next()) {
                 names.add(dbrs.getString(2));
             }
+            dbrs.close();
+            stmt.close();
         } catch (Exception exp) {
             logger.error("Failed to find current binders list in postgres",exp);
         }

--- a/src/main/java/io/mewbase/projection/impl/ProjectionManagerImpl.java
+++ b/src/main/java/io/mewbase/projection/impl/ProjectionManagerImpl.java
@@ -30,7 +30,7 @@ public class ProjectionManagerImpl implements ProjectionManager {
     private final EventSource source;
     private final BinderStore store;
 
-    public static final String PROJ_STATE_BINDER_NAME = "mewbase.proj.state";
+    public static final String PROJ_STATE_BINDER_NAME = "mewbase_proj_state";
     public static final String EVENT_NUM_FIELD = "eventNum";
 
     private final Binder stateBinder;

--- a/src/test/java/io/mewbase/binder/BindersTest.java
+++ b/src/test/java/io/mewbase/binder/BindersTest.java
@@ -38,14 +38,13 @@ import static org.junit.Assert.*;
 @RunWith(VertxUnitRunner.class)
 public class BindersTest extends MewbaseTestBase {
 
-    private final static String BINDER_NAME = "TestBinderName";
 
 
     @Test
     public void testCreateBinderStore() throws Exception {
         BinderStore store = BinderStore.instance(createMewbaseOptions());
-        store.binderNames().forEach( bn-> System.out.println(bn));
-        assertEquals(store.binderNames().count(),0L);
+        // doesnt throw exceptions and does return a valid handle to store
+        assertNotNull(store);
     }
 
 
@@ -53,20 +52,21 @@ public class BindersTest extends MewbaseTestBase {
     public void testOpenBinders() throws Exception {
 
         // set up the store and add some binders
+        final String testBinderName = new Object(){}.getClass().getEnclosingMethod().getName();
         BinderStore store = BinderStore.instance(createMewbaseOptions());
 
         final int numBinders = 10;
         Binder[] all = new Binder[numBinders];
         IntStream.range(0, all.length).forEach( i -> {
-            all[i] = store.open("testbinder" + i);
+            all[i] = store.open(testBinderName + i);
         });
 
         Set<String> bindersSet1 = store.binderNames().collect(toSet());
         for (int i = 0; i < numBinders; i++) {
-            assertTrue(bindersSet1.contains("testbinder" + i));
+            assertTrue(bindersSet1.contains(testBinderName + i));
         }
 
-        final String name = "AnotherBinder";
+        final String name = "YetAnother" + testBinderName;
         store.open(name);
         Set<String> bindersSet2 = store.binderNames().collect(toSet());
         assertTrue(bindersSet2.contains(name));
@@ -79,7 +79,9 @@ public class BindersTest extends MewbaseTestBase {
    public void testSimplePutGet() throws Exception {
 
        BinderStore store = BinderStore.instance(createMewbaseOptions());
-       Binder binder = store.open(BINDER_NAME);
+       final String testBinderName = new Object(){}.getClass().getEnclosingMethod().getName();
+
+       Binder binder = store.open(testBinderName);
        BsonObject docPut = createObject();
        assertNull(binder.put("id1234", docPut).get());
        BsonObject docGet = binder.get("id1234").get();
@@ -97,10 +99,10 @@ public class BindersTest extends MewbaseTestBase {
     @Test
     public void testAsyncWriteReadInterleaved() throws Exception {
 
-        // Binder store must satisfy 'linearize' properties.
+        final String testBinderName = new Object(){}.getClass().getEnclosingMethod().getName();
 
         final BinderStore store = BinderStore.instance(createMewbaseOptions());
-        final Binder binder = store.open(BINDER_NAME);
+        final Binder binder = store.open(testBinderName);
 
         final String TEST_KEY  = "InOrderTest";
         final BsonObject docToWrite = new BsonObject().put("Thing1", "Bad").put("Thing2", "Worse");
@@ -125,8 +127,10 @@ public class BindersTest extends MewbaseTestBase {
     @Test
     public void testPutGetDifferentBinders() throws Exception {
 
-        final String B1 = BINDER_NAME + "1";
-        final String B2 = BINDER_NAME + "2";
+        final String testBinderName = new Object(){}.getClass().getEnclosingMethod().getName();
+
+        final String B1 = testBinderName + "1";
+        final String B2 = testBinderName + "2";
 
         BinderStore store = BinderStore.instance(createMewbaseOptions());
         Binder binder1 = store.open(B1);
@@ -152,15 +156,16 @@ public class BindersTest extends MewbaseTestBase {
     public void testBinderIsPersistent() throws Exception {
 
         final MewbaseOptions OPTIONS = createMewbaseOptions();
+        final String testBinderName = new Object(){}.getClass().getEnclosingMethod().getName();
 
         BinderStore store = BinderStore.instance(OPTIONS);
-        Binder binder = store.open(BINDER_NAME);
+        Binder binder = store.open(testBinderName);
         BsonObject docPut = createObject();
         binder.put("id1234", docPut).get();
 
 
         BinderStore store2 = BinderStore.instance(OPTIONS);
-        Binder binder2 = store2.open(BINDER_NAME);
+        Binder binder2 = store2.open(testBinderName);
         BsonObject docGet = binder2.get("id1234").get();
         assertEquals(docPut, docGet);
     }
@@ -169,8 +174,10 @@ public class BindersTest extends MewbaseTestBase {
     @Test
     public void testBinderSerialisesPutsAndGetsCorrectly() throws Exception {
 
+        final String testBinderName = new Object(){}.getClass().getEnclosingMethod().getName();
+
         BinderStore store = BinderStore.instance(createMewbaseOptions());
-        Binder binder = store.open(BINDER_NAME);
+        Binder binder = store.open(testBinderName);
         final String DOC_ID = "ID1234567";
         final String FIELD_KEY = "K";
         BsonObject doc = createObject();
@@ -182,8 +189,10 @@ public class BindersTest extends MewbaseTestBase {
 
     @Test
     public void testFindNoEntry() throws Exception {
+        final String testBinderName = new Object(){}.getClass().getEnclosingMethod().getName();
+
         BinderStore store = BinderStore.instance(createMewbaseOptions());
-        Binder binder = store.open(BINDER_NAME);
+        Binder binder = store.open(testBinderName);
         assertNull(binder.get("id1234").get());
 
     }
@@ -191,8 +200,11 @@ public class BindersTest extends MewbaseTestBase {
 
     @Test
     public void testDelete() throws Exception {
+
+        final String testBinderName = new Object(){}.getClass().getEnclosingMethod().getName();
+
         BinderStore store = BinderStore.instance(createMewbaseOptions());
-        Binder binder = store.open(BINDER_NAME);
+        Binder binder = store.open(testBinderName);
 
         BsonObject docPut = createObject();
         assertNull(binder.put("id1234", docPut).get());
@@ -207,8 +219,10 @@ public class BindersTest extends MewbaseTestBase {
     @Test
     public void testGetAll() throws Exception {
 
+        final String testBinderName = new Object(){}.getClass().getEnclosingMethod().getName();
+
         BinderStore store = BinderStore.instance(createMewbaseOptions());;
-        Binder binder = store.open(BINDER_NAME);
+        Binder binder = store.open(testBinderName);
 
         final int MANY_DOCS = 64;
         final String DOC_ID_KEY = "id";
@@ -242,8 +256,10 @@ public class BindersTest extends MewbaseTestBase {
     @Test
     public void testGetWithFilter() throws Exception {
 
+        final String testBinderName = new Object(){}.getClass().getEnclosingMethod().getName();
+
         BinderStore store = BinderStore.instance(createMewbaseOptions());
-        Binder binder = store.open(BINDER_NAME);
+        Binder binder = store.open(testBinderName);
 
         final int ALL_DOCS = 64;
         final String DOC_ID_KEY = "id";
@@ -252,7 +268,7 @@ public class BindersTest extends MewbaseTestBase {
 
         range.forEach(i -> {
             final BsonObject docPut = createObject();
-            binder.put(String.valueOf(i), docPut.put(DOC_ID_KEY, i));
+            binder.put(String.valueOf(i), docPut.put(DOC_ID_KEY, i)).join();
         });
 
         // get with filter
@@ -271,15 +287,16 @@ public class BindersTest extends MewbaseTestBase {
         Predicate<BsonObject> filter = doc -> doc.getInteger(DOC_ID_KEY) <= HALF_THE_DOCS;
         Stream<KeyVal<String, BsonObject>> docs = binder.getDocuments(new HashSet(),filter);
 
-        assertEquals(docs.map(checker).collect(toSet()).size(), HALF_THE_DOCS);
+        assertEquals(HALF_THE_DOCS, docs.map(checker).collect(toSet()).size());
 
     }
 
     @Test
     public void testGetWithIdSet() throws Exception {
 
-        BinderStore store = BinderStore.instance(createMewbaseOptions());;
-        Binder binder = store.open(BINDER_NAME);
+        BinderStore store = BinderStore.instance(createMewbaseOptions());
+        final String testBinderName = new Object(){}.getClass().getEnclosingMethod().getName();
+        Binder binder = store.open(testBinderName);
 
         final int ALL_DOCS = 64;
         final String DOC_ID_KEY = "id";
@@ -321,12 +338,14 @@ public class BindersTest extends MewbaseTestBase {
     }
 
 
-    //@Test
+    // @Test
     public void testPerformance() throws Exception {
 
+        final String testBinderName = new Object(){}.getClass().getEnclosingMethod().getName();
         final BinderStore store = BinderStore.instance(createMewbaseOptions());
         // final BinderStore store = new LmdbBinderStore();
-        final Binder binder = store.open(BINDER_NAME);
+
+        final Binder binder = store.open(testBinderName);
 
         final BsonObject docToWrite = new BsonObject().put("Thing1","Bad").put("Thing2","Worse");
 
@@ -353,7 +372,7 @@ public class BindersTest extends MewbaseTestBase {
         }
 
 
-        iterations = 1000000;
+        iterations = 100000;
         {
             final String test = "Async Writes";
             final long start = System.currentTimeMillis();


### PR DESCRIPTION
This PR contains an Implementation of a Binder Store for the Postgress (and clones) DataBase.

All tests pass for both the FileStore and the PostgresStore but we have wound the tests back to FIleStore for this PR for regression reasons.

The ability to configure the tests using a config tool would be great help for testing multiple implementations of the EventStore and BinderStore. This is next on the Back log #147 

This PR answers #145 