### PR TITLE
Multi Event Sink

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_install:
 # - docker run -p 4222:4222 -p 8222:8222 -d  nats-streaming
 # - docker run -p 5432:5432 -e POSTGRES_PASSWORD=mewbase -e POSTGRES_USER=mewbase  # port collision with DockerCompose
 # - docker run -p8161:8161 -p 61616:61616 -d -e ARTEMIS_USERNAME=admin -e ARTEMIS_PASSWORD=admin vromero/activemq-artemis
-# -  docker ps -a
+# - docker ps -a
 
 jdk:
 - oraclejdk8

--- a/src/main/java/io/mewbase/eventsource/MultiEventSink.java
+++ b/src/main/java/io/mewbase/eventsource/MultiEventSink.java
@@ -3,18 +3,21 @@ package io.mewbase.eventsource;
 import io.mewbase.bson.BsonObject;
 import io.mewbase.eventsource.impl.MultiEventSinkImpl;
 
-import java.util.Set;
+import java.util.Arrays;
+import java.util.HashSet;
+
 import java.util.concurrent.Future;
 import java.util.stream.Stream;
+
 
 public interface MultiEventSink  {
 
 
-    static MultiEventSink instance(Set<EventSink> sinks) {
-        if (sinks.size() < 2) {
+    static MultiEventSink instance(EventSink... sinks) {
+        if (sinks.length < 2) {
             throw new IllegalStateException("MultiEvent sink must have at least two embedded sinks.");
         }
-        new MultiEventSinkImpl( sinks );
+        return new MultiEventSinkImpl( new HashSet<>(Arrays.asList(sinks)) );
     }
 
     Stream<Long> publishSync(String channelName, BsonObject event);

--- a/src/main/java/io/mewbase/eventsource/MultiEventSink.java
+++ b/src/main/java/io/mewbase/eventsource/MultiEventSink.java
@@ -1,0 +1,25 @@
+package io.mewbase.eventsource;
+
+import io.mewbase.bson.BsonObject;
+import io.mewbase.eventsource.impl.MultiEventSinkImpl;
+
+import java.util.Set;
+import java.util.concurrent.Future;
+import java.util.stream.Stream;
+
+public interface MultiEventSink  {
+
+
+    static MultiEventSink instance(Set<EventSink> sinks) {
+        if (sinks.size() < 2) {
+            throw new IllegalStateException("MultiEvent sink must have at least two embedded sinks.");
+        }
+        new MultiEventSinkImpl( sinks );
+    }
+
+    Stream<Long> publishSync(String channelName, BsonObject event);
+
+    Future<Stream<Long>> publishAsync(String channelName, BsonObject event);
+
+    void close();
+}

--- a/src/main/java/io/mewbase/eventsource/impl/MultiEventSinkImpl.java
+++ b/src/main/java/io/mewbase/eventsource/impl/MultiEventSinkImpl.java
@@ -13,6 +13,7 @@ import java.util.concurrent.Future;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+
 public class MultiEventSinkImpl implements MultiEventSink {
 
     private final static Logger logger = LoggerFactory.getLogger(MultiEventSinkImpl.class);
@@ -20,19 +21,22 @@ public class MultiEventSinkImpl implements MultiEventSink {
     final Set<EventSink> sinks;
     final ExecutorService exec = Executors.newWorkStealingPool();
 
-    MultiEventSinkImpl(Set<EventSink> sinks) {
+    public MultiEventSinkImpl(Set<EventSink> sinks) {
         this.sinks = sinks;
     }
 
     @Override
     public Stream<Long> publishSync(String channelName, BsonObject event) {
-        return sinks.parallelStream().map ( sink -> {
-            try {
-                return sink.publishSync(channelName, event);
-            } catch (Exception exp ) {
-                logger.error("Sink " + sink + "failed to publish event" + event);
-            }
-         ).collect(Collectors.toList());
+        return sinks.parallelStream().map( sink -> {
+                    try {
+                        return sink.publishSync(channelName, event);
+                    } catch (Exception exp) {
+                        logger.error("Sink " + sink + "failed to publish event" + event);
+                    }
+                    return -1L;
+                })
+                .collect(Collectors.toList())
+                .stream();
     }
 
     @Override
@@ -51,6 +55,6 @@ public class MultiEventSinkImpl implements MultiEventSink {
     }
 
     @Override
-    public void close() { sinks.forEach( sink -> sink.close() );
+    public void close() { sinks.forEach( sink -> sink.close() ); }
 
 }

--- a/src/main/java/io/mewbase/eventsource/impl/MultiEventSinkImpl.java
+++ b/src/main/java/io/mewbase/eventsource/impl/MultiEventSinkImpl.java
@@ -1,0 +1,56 @@
+package io.mewbase.eventsource.impl;
+
+import io.mewbase.bson.BsonObject;
+import io.mewbase.eventsource.EventSink;
+import io.mewbase.eventsource.MultiEventSink;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class MultiEventSinkImpl implements MultiEventSink {
+
+    private final static Logger logger = LoggerFactory.getLogger(MultiEventSinkImpl.class);
+
+    final Set<EventSink> sinks;
+    final ExecutorService exec = Executors.newWorkStealingPool();
+
+    MultiEventSinkImpl(Set<EventSink> sinks) {
+        this.sinks = sinks;
+    }
+
+    @Override
+    public Stream<Long> publishSync(String channelName, BsonObject event) {
+        return sinks.parallelStream().map ( sink -> {
+            try {
+                return sink.publishSync(channelName, event);
+            } catch (Exception exp ) {
+                logger.error("Sink " + sink + "failed to publish event" + event);
+            }
+         ).collect(Collectors.toList());
+    }
+
+    @Override
+    public Future<Stream<Long>> publishAsync(String channelName, BsonObject event) {
+        Future<Stream<Long>> fut = exec.submit( () -> {
+             Stream<Long> nums = sinks
+                    .stream()
+                    .parallel()
+                    .map(sink -> sink.publishAsync(channelName,event) )
+                    .map( futOfLong -> futOfLong.join() )
+                    .collect(Collectors.toList())
+                    .stream();
+             return nums;
+        });
+        return fut;
+    }
+
+    @Override
+    public void close() { sinks.forEach( sink -> sink.close() );
+
+}

--- a/src/test/java/io/mewbase/eventsource/EventSinkTest.java
+++ b/src/test/java/io/mewbase/eventsource/EventSinkTest.java
@@ -5,16 +5,9 @@ import io.mewbase.MewbaseTestBase;
 
 import io.mewbase.bson.BsonObject;
 
-import io.vertx.ext.unit.junit.VertxUnitRunner;
-import org.junit.Test;
-import org.junit.runner.RunWith;
 
-import javax.jms.BytesMessage;
-import javax.jms.Destination;
-import javax.jms.JMSException;
-import javax.jms.MessageProducer;
-import java.io.IOException;
-import java.io.UncheckedIOException;
+import org.junit.Test;
+
 import java.util.List;
 
 import java.util.UUID;
@@ -24,8 +17,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.LongStream;
 
-
-import static junit.framework.TestCase.assertTrue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 

--- a/src/test/java/io/mewbase/eventsource/MultiEventSinkTest.java
+++ b/src/test/java/io/mewbase/eventsource/MultiEventSinkTest.java
@@ -1,0 +1,86 @@
+package io.mewbase.eventsource;
+
+import com.typesafe.config.Config;
+import io.mewbase.MewbaseTestBase;
+import io.mewbase.bson.BsonObject;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
+import java.util.stream.LongStream;
+import java.util.stream.Stream;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+/**
+ * Created by Nige on 26/2/2018.
+ */
+
+public class MultiEventSinkTest extends MewbaseTestBase {
+
+    class StubEventSink implements EventSink {
+
+        AtomicLong publishSync = new AtomicLong(0);
+        AtomicLong publishAsync = new AtomicLong(0);
+        AtomicLong close = new AtomicLong(0);
+
+        @Override
+        public Long publishSync(String channelName, BsonObject event) {
+            return publishSync.incrementAndGet();
+        }
+
+        @Override
+        public CompletableFuture<Long> publishAsync(String channelName, BsonObject event) {
+            return CompletableFuture.completedFuture( publishAsync.incrementAndGet() );
+        }
+
+        @Override
+        public void close() {
+            close.incrementAndGet();
+        }
+    }
+
+
+    @Test
+    public void testCreateAndCloseMulti()  {
+        final EventSink es1 = new StubEventSink();
+        final EventSink es2 = new StubEventSink();
+        final MultiEventSink mes = MultiEventSink.instance(es1,es2);
+        mes.close();
+        assertEquals(1L, ((StubEventSink)es1).close.get() );
+        assertEquals(1L, ((StubEventSink)es2).close.get() );
+    }
+
+
+
+    @Test
+    public void testPublishSingleEventMultiply() throws Exception {
+
+        final EventSink es1 = new StubEventSink();
+        final EventSink es2 = new StubEventSink();
+        final MultiEventSink mes = MultiEventSink.instance(es1,es2);
+        mes.close();
+        assertEquals(1L, ((StubEventSink)es1).close.get() );
+        assertEquals(1L, ((StubEventSink)es2).close.get() );
+
+        final String channelName = "StubEventChannel";
+        final BsonObject event = new BsonObject().put("data", UUID.randomUUID().toString());
+        final Stream<Long> evtNums = mes.publishSync(channelName, event);
+
+        //long size = evtNums.map( (Long l) -> assertEquals(0L, (long)l ) ).count();
+        //assertEquals(2L, size);
+
+        mes.close();
+    }
+
+
+
+
+
+}

--- a/src/test/java/io/mewbase/eventsource/MultiEventSinkTest.java
+++ b/src/test/java/io/mewbase/eventsource/MultiEventSinkTest.java
@@ -1,22 +1,20 @@
 package io.mewbase.eventsource;
 
-import com.typesafe.config.Config;
+
 import io.mewbase.MewbaseTestBase;
 import io.mewbase.bson.BsonObject;
 import org.junit.Test;
 
-import java.util.List;
+
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.stream.Collectors;
 import java.util.stream.LongStream;
 import java.util.stream.Stream;
 
+
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+
 
 /**
  * Created by Nige on 26/2/2018.
@@ -32,17 +30,17 @@ public class MultiEventSinkTest extends MewbaseTestBase {
 
         @Override
         public Long publishSync(String channelName, BsonObject event) {
-            return publishSync.incrementAndGet();
+            return publishSync.getAndIncrement();
         }
 
         @Override
         public CompletableFuture<Long> publishAsync(String channelName, BsonObject event) {
-            return CompletableFuture.completedFuture( publishAsync.incrementAndGet() );
+            return CompletableFuture.completedFuture( publishAsync.getAndIncrement() );
         }
 
         @Override
         public void close() {
-            close.incrementAndGet();
+            close.getAndIncrement();
         }
     }
 
@@ -60,7 +58,7 @@ public class MultiEventSinkTest extends MewbaseTestBase {
 
 
     @Test
-    public void testPublishSingleEventMultiply() throws Exception {
+    public void testPublishSingleEventMultiply()  {
 
         final EventSink es1 = new StubEventSink();
         final EventSink es2 = new StubEventSink();
@@ -73,13 +71,40 @@ public class MultiEventSinkTest extends MewbaseTestBase {
         final BsonObject event = new BsonObject().put("data", UUID.randomUUID().toString());
         final Stream<Long> evtNums = mes.publishSync(channelName, event);
 
-        //long size = evtNums.map( (Long l) -> assertEquals(0L, (long)l ) ).count();
-        //assertEquals(2L, size);
+        long size = evtNums.map( (Long l) -> {
+            assertEquals(0L, (long)l );
+            return 1;
+        }  ).count();
+        assertEquals(2L, size);
 
         mes.close();
     }
 
 
+    @Test
+    public void testPublishMultiEventMultiply()  {
+
+        final long numEventSinks = 7;
+        final EventSink[] eventSinks = new EventSink[(int)numEventSinks];
+        for (int i = 0; i < numEventSinks; i++) eventSinks[i] = EventSink.instance();
+
+        final MultiEventSink mes = MultiEventSink.instance(eventSinks);
+        final String channelName = "StubEventChannel";
+
+        final long numEventsToPublish = 16;
+        LongStream.range(0, numEventsToPublish)
+                .mapToObj( l -> {
+                    final BsonObject event = new BsonObject().put("data", UUID.randomUUID().toString());
+                    final CompletableFuture<Stream<Long>> evtNums = (CompletableFuture)mes.publishAsync(channelName, event);
+                    evtNums.thenAccept( (Stream<Long> sl ) ->
+                            assertEquals( sl.map( (Long p) -> {
+                                        assertEquals((long) p, l);
+                                        return 1;
+                                    } ).count(),  numEventSinks ) );
+                    return null;
+                } );
+        mes.close();
+    }
 
 
 

--- a/src/test/java/io/mewbase/eventsource/impl/jms/JMSEventSinkTest.java
+++ b/src/test/java/io/mewbase/eventsource/impl/jms/JMSEventSinkTest.java
@@ -7,8 +7,6 @@ import io.mewbase.MewbaseTestBase;
 import io.mewbase.bson.BsonObject;
 import io.mewbase.eventsource.EventSink;
 
-import org.junit.Test;
-
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
@@ -16,7 +14,6 @@ import java.util.stream.IntStream;
 
 import static junit.framework.TestCase.assertNotNull;
 import static org.junit.Assert.assertEquals;
-
 
 /**
  * Created by Nige on 16/2/2018.


### PR DESCRIPTION
Add the ability to have at least two EventSink instances behind a single EventSink Interface instance.

For example a single Async write can be directed to two 'extenal' Event Stores (e.g. JMS and Nats.io)

