### PR TITLE
More idiomatic scala / http4s support and syntax

### DIFF
--- a/examples-scala/src/main/scala/example/gettingstarted/commandrest/Main.scala
+++ b/examples-scala/src/main/scala/example/gettingstarted/commandrest/Main.scala
@@ -9,9 +9,9 @@ import io.mewbase.bson.BsonObject
 import io.mewbase.cqrs.CommandManager
 import io.mewbase.eventsource.{EventSink, EventSource}
 import io.mewbase.projection.ProjectionManager
-import io.mewbase.rest.{RestServiceAction, RestServiceAdaptor}
-import io.mewbase.rest.http4s.Http4sRestServiceActionVisitor
-import org.http4s.HttpService
+import io.mewbase.rest._
+import io.mewbase.rest.http4s.{Http4sRestServiceActionVisitor, MewbaseSupport}
+import org.http4s.{HttpService, Response}
 import org.http4s.dsl.Http4sDsl
 import org.http4s.circe._
 import org.http4s.server.blaze.BlazeBuilder
@@ -23,10 +23,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 This example shows how to use a expose a mewbase component (CommandManager) through an
 existing http4s service
  */
-
-class HelloWorldService(commandManager: CommandManager) extends Http4sDsl[IO] {
-
-  val actionVisitor = new Http4sRestServiceActionVisitor[IO]
+class HelloWorldService(commandManager: CommandManager) extends Http4sDsl[IO] with MewbaseSupport {
 
   val helloWorldService: HttpService[IO] = HttpService[IO] {
 
@@ -35,14 +32,14 @@ class HelloWorldService(commandManager: CommandManager) extends Http4sDsl[IO] {
 
     case req@POST -> Root / "buy" =>
       req.as[BsonObject].flatMap { body =>
-        actionVisitor.visit(RestServiceAction.executeCommand(commandManager, Main.buyCommand.getName, body))
+        ExecuteCommand(commandManager, Main.buyCommand.getName, body)
       }
 
     case GET -> Root / "purchase" =>
-      actionVisitor.visit(RestServiceAction.listDocumentIds(Main.binderStore, Main.projectionOutputChannel))
+      ListDocumentIds(Main.binderStore, Main.projectionOutputChannel)
 
     case GET -> Root / "purchase" / purchaseNumber =>
-      actionVisitor.visit(RestServiceAction.retrieveSingleDocument(Main.binderStore, Main.projectionOutputChannel, purchaseNumber))
+      RetrieveSingleDocument(Main.binderStore, Main.projectionOutputChannel, purchaseNumber)
 
   }
 

--- a/mewbase-core/src/main/scala/io/mewbase/bson/syntax/package.scala
+++ b/mewbase-core/src/main/scala/io/mewbase/bson/syntax/package.scala
@@ -1,0 +1,184 @@
+package io.mewbase.bson
+
+import io.mewbase
+import io.mewbase.bson
+import io.mewbase.bson.BsonValue.StringBsonValue
+
+import scala.reflect.ClassTag
+
+package object syntax {
+
+  implicit class BsonObjectSyntax(val bsonObject: BsonObject) {
+
+    def getOrBsonNull(key: String): BsonValue =
+      bsonObject.getBsonValue(key)
+
+    def apply(key: String): Option[BsonValue] = {
+      val value = bsonObject.getBsonValue(key)
+
+      if (value.isNull)
+        None
+      else
+        Some(value)
+    }
+
+  }
+
+  implicit class BsonArraySyntax(val bsonArray: BsonArray) {
+
+    def apply(index: Int): Option[BsonValue] =
+      if (index < bsonArray.size())
+        Some(bsonArray.getBsonValue(index))
+      else
+        None
+
+  }
+
+  implicit class FieldIterableSyntax(val fields: Iterable[(String, BsonValue)]) {
+
+    def bsonObject: BsonObject = {
+      val result = new BsonObject()
+      fields.foreach {
+        case (fieldName, fieldValue) =>
+          result.put(fieldName, fieldValue)
+      }
+      result
+    }
+
+  }
+
+  implicit class ValueIterableSyntax(val values: Iterable[BsonValue]) {
+
+    def bsonArray: BsonArray = {
+      val result = new BsonArray()
+      values.foreach(result.add)
+      result
+    }
+  }
+
+  sealed trait LiftBsonValue[T] {
+    def lift(value: T): BsonValue
+  }
+  object LiftBsonValue {
+    def apply[T](f: T => BsonValue): LiftBsonValue[T] = new LiftBsonValue[T] {
+      override def lift(value: T): BsonValue = f(value)
+    }
+  }
+
+  implicit val LiftStringBsonValue: LiftBsonValue[String] = LiftBsonValue[String](BsonValue.of)
+  implicit val LiftIntBsonValue: LiftBsonValue[Int] = LiftBsonValue[Int](i => BsonValue.of(i.toLong))
+  implicit val LiftLongBsonValue: LiftBsonValue[Long] = LiftBsonValue[Long](BsonValue.of)
+  implicit val LiftDoubleBsonValue: LiftBsonValue[Double] = LiftBsonValue[Double](BsonValue.of)
+  implicit val LiftFloatBsonValue: LiftBsonValue[Float] = LiftBsonValue[Float](f => BsonValue.of(f.toDouble))
+
+  implicit val LiftBooleanBsonValue: LiftBsonValue[Boolean] = LiftBsonValue[Boolean](BsonValue.of)
+
+  implicit val LiftBsonObjectBsonValue: LiftBsonValue[BsonObject] = LiftBsonValue[BsonObject](BsonValue.of)
+
+  implicit val LiftBsonArrayBsonValue: LiftBsonValue[BsonArray] = LiftBsonValue[BsonArray](BsonValue.of)
+
+  implicit def LiftOptionBsonValue[T](implicit liftDefined: LiftBsonValue[T]): LiftBsonValue[Option[T]] =
+    new LiftBsonValue[Option[T]] {
+      override def lift(value: Option[T]): BsonValue =
+        value match {
+          case Some(v) => liftDefined.lift(v)
+          case None => BsonValue.nullValue()
+        }
+    }
+
+  implicit class LiftBsonValueSyntax[T](val value: T) {
+
+    def bsonValue(implicit liftBsonValue: LiftBsonValue[T]): BsonValue =
+      liftBsonValue.lift(value)
+
+  }
+
+  type Result[A] = Either[String, A]
+
+  sealed trait BsonValueDecoder[T] {
+    def decode(value: BsonValue): Result[T]
+  }
+
+  object BsonValueDecoder {
+    class WrongType[T](implicit classTag: ClassTag[T]) extends BsonValue.Visitor[Result[T]] {
+      def result(value: BsonValue): Result[T] =
+        Left(s"Unable to decode '$value' into a ${classTag.toString()}")
+
+      override def visit(nullValue: BsonValue.NullBsonValue): Result[T] = result(nullValue)
+      override def visit(value: StringBsonValue): Result[T] = result(value)
+      override def visit(value: BsonValue.BigDecimalBsonValue): Result[T] = result(value)
+      override def visit(value: BsonValue.BooleanBsonValue): Result[T] = result(value)
+      override def visit(value: BsonValue.BsonObjectBsonValue): Result[T] = result(value)
+      override def visit(value: BsonValue.BsonArrayBsonValue): Result[T] = result(value)
+    }
+
+    def apply[T](visitor: BsonValue.Visitor[Result[T]]): BsonValueDecoder[T] =
+      new BsonValueDecoder[T] {
+        override def decode(value: BsonValue): Result[T] =
+          value.visit(visitor)
+      }
+  }
+
+  implicit val StringBsonValueDecoder: BsonValueDecoder[String] = BsonValueDecoder[String] {
+    new bson.syntax.BsonValueDecoder.WrongType[String] {
+      override def visit(value: StringBsonValue): Result[String] =
+        Right(value.getValue)
+    }
+  }
+
+  implicit val IntBsonValueDecoder: BsonValueDecoder[Int] = BsonValueDecoder[Int] {
+    new mewbase.bson.syntax.BsonValueDecoder.WrongType[Int] {
+      override def visit(value: BsonValue.BigDecimalBsonValue): Result[Int] =
+        Right(value.getValue.intValue())
+    }
+  }
+
+  implicit val LongBsonValueDecoder: BsonValueDecoder[Long] = BsonValueDecoder[Long] {
+    new mewbase.bson.syntax.BsonValueDecoder.WrongType[Long] {
+      override def visit(value: BsonValue.BigDecimalBsonValue): Result[Long] =
+        Right(value.getValue.longValue())
+    }
+  }
+
+  implicit val FloatBsonValueDecoder: BsonValueDecoder[Float] = BsonValueDecoder[Float] {
+    new mewbase.bson.syntax.BsonValueDecoder.WrongType[Float] {
+      override def visit(value: BsonValue.BigDecimalBsonValue): Result[Float] =
+        Right(value.getValue.floatValue())
+    }
+  }
+
+  implicit val DoubleBsonValueDecoder: BsonValueDecoder[Double] = BsonValueDecoder[Double] {
+    new mewbase.bson.syntax.BsonValueDecoder.WrongType[Double] {
+      override def visit(value: BsonValue.BigDecimalBsonValue): Result[Double] =
+        Right(value.getValue.doubleValue())
+    }
+  }
+
+  implicit val BooleanBsonValueDecoder: BsonValueDecoder[Boolean] = BsonValueDecoder[Boolean] {
+    new mewbase.bson.syntax.BsonValueDecoder.WrongType[Boolean] {
+      override def visit(value: BsonValue.BooleanBsonValue): Result[Boolean] =
+        Right(value.getValue)
+    }
+  }
+
+  implicit val BsonObjectBsonValueDecoder: BsonValueDecoder[BsonObject] = BsonValueDecoder[BsonObject] {
+    new mewbase.bson.syntax.BsonValueDecoder.WrongType[BsonObject] {
+      override def visit(value: BsonValue.BsonObjectBsonValue): Result[BsonObject] =
+        Right(value.getValue)
+    }
+  }
+
+  implicit val BsonArrayBsonValueDecoder: BsonValueDecoder[BsonArray] = BsonValueDecoder[BsonArray] {
+    new mewbase.bson.syntax.BsonValueDecoder.WrongType[BsonArray] {
+      override def visit(value: BsonValue.BsonArrayBsonValue): Result[BsonArray] =
+        Right(value.getValue)
+    }
+  }
+
+  implicit class BsonValueSyntax(val bsonValue: BsonValue) {
+
+    def to[T](implicit decoder: BsonValueDecoder[T]): Result[T] =
+      decoder.decode(bsonValue)
+
+  }
+}

--- a/mewbase-core/src/main/scala/io/mewbase/rest/RestServiceActionWrappers.scala
+++ b/mewbase-core/src/main/scala/io/mewbase/rest/RestServiceActionWrappers.scala
@@ -1,0 +1,47 @@
+package io.mewbase.rest
+
+import io.mewbase.binders.BinderStore
+import io.mewbase.bson.BsonObject
+import io.mewbase.cqrs.{CommandManager, QueryManager}
+
+object RetrieveSingleDocument {
+
+  def apply(binderStore: BinderStore, binderName: String, documentId: String): RestServiceAction.RetrieveSingleDocument =
+    RestServiceAction.retrieveSingleDocument(binderStore, binderName, documentId)
+
+}
+
+object ListDocumentIds {
+
+  def apply(binderStore: BinderStore, binderName: String): RestServiceAction.ListDocumentIds =
+    RestServiceAction.listDocumentIds(binderStore, binderName)
+
+}
+
+object ExecuteCommand {
+
+  def apply(commandManager: CommandManager, commandName: String, context: BsonObject): RestServiceAction.ExecuteCommand =
+    RestServiceAction.executeCommand(commandManager, commandName, context)
+
+}
+
+object RunQuery {
+
+  def apply(queryManager: QueryManager, queryName: String, context: BsonObject): RestServiceAction.RunQuery =
+    RestServiceAction.runQuery(queryManager, queryName, context)
+
+}
+
+object ListBinders {
+
+  def apply(binderStore: BinderStore): RestServiceAction.ListBinders =
+    RestServiceAction.listBinders(binderStore)
+
+}
+
+object GetMetrics {
+
+  def apply(): RestServiceAction.GetMetrics =
+    RestServiceAction.getMetrics
+
+}

--- a/mewbase-core/src/test/scala/io/mewbase/bson/syntax/BsonSyntaxTest.scala
+++ b/mewbase-core/src/test/scala/io/mewbase/bson/syntax/BsonSyntaxTest.scala
@@ -1,0 +1,130 @@
+package io.mewbase.bson.syntax
+
+import io.mewbase.bson.{BsonArray, BsonObject}
+import io.mewbase.bson.BsonValue._
+import org.scalatest.{FunSuite, Matchers}
+
+class BsonObjectSyntaxTest extends FunSuite with Matchers {
+
+  test("get missing value results in an empty option") {
+    val bsonObject = new BsonObject()
+
+    bsonObject("name") shouldBe None
+  }
+
+  test("get a present value results in a defined option") {
+    val bsonObject = new BsonObject()
+
+    bsonObject.put("name", "Martin")
+
+    bsonObject("name") shouldBe 'defined
+  }
+
+  test("build bson object") {
+    val bsonObject =
+      Seq("hello" -> "world".bsonValue, "count" -> 1.bsonValue).bsonObject
+    bsonObject("hello").map(_.to[String]) shouldBe Some(Right("world"))
+  }
+
+}
+
+class BsonArraySyntaxTest extends FunSuite with Matchers {
+
+  test("build bson array") {
+    val bsonArray =
+      Seq(123.bsonValue, "hello".bsonValue).bsonArray
+    bsonArray(1) shouldBe Some("hello".bsonValue)
+  }
+
+  test("get index out of bounds") {
+    val bsonArray = new BsonArray()
+    bsonArray(0) shouldBe None
+  }
+
+}
+
+class BsonValueSyntaxTest extends FunSuite with Matchers {
+
+  test("lift a String") {
+    "Hello, world".bsonValue shouldBe a[StringBsonValue]
+  }
+
+  test("lift a Double") {
+    3.14d.bsonValue shouldBe a[BigDecimalBsonValue]
+  }
+
+
+  test("lift a Long") {
+    1234L.bsonValue shouldBe a[BigDecimalBsonValue]
+  }
+
+  test("lift an Int") {
+    3.bsonValue shouldBe a[BigDecimalBsonValue]
+  }
+
+  test("lift a Float") {
+    3.14f.bsonValue shouldBe a[BigDecimalBsonValue]
+  }
+
+  test("lift a boolean") {
+    true.bsonValue shouldBe a[BooleanBsonValue]
+  }
+
+  test("lift a bsonobject") {
+    val bsonObject = new BsonObject()
+    bsonObject.put("hello", "world")
+    bsonObject.bsonValue shouldBe a [BsonObjectBsonValue]
+  }
+
+  test("lift a bsonarray") {
+    val bsonArray = new BsonArray()
+    bsonArray.add("hello")
+    bsonArray.bsonValue shouldBe a [BsonArrayBsonValue]
+  }
+
+  test("lift an undefined option") {
+    val value: Option[String] = None
+    value.bsonValue shouldBe a [NullBsonValue]
+  }
+
+  test("lift a defined option") {
+    val value: Option[String] = Some("Hello")
+    value.bsonValue shouldBe a [StringBsonValue]
+  }
+
+  test("decode a string") {
+    "hello".bsonValue.to[String] shouldBe Right("hello")
+  }
+  test("decode an int to a string") {
+    123.bsonValue.to[String] shouldBe a[Left[_, _]]
+  }
+
+  test("decode an int") {
+    123.bsonValue.to[Int] shouldBe Right(123)
+  }
+
+  test("decode a long") {
+    123L.bsonValue.to[Long] shouldBe Right(123L)
+  }
+
+  test("decode a Double") {
+    123d.bsonValue.to[Double] shouldBe Right(123d)
+  }
+
+  test("decode a Float") {
+    123f.bsonValue.to[Float] shouldBe Right(123f)
+  }
+
+  test("decode a boolean") {
+    true.bsonValue.to[Boolean] shouldBe Right(true)
+  }
+
+  test("decode a bsonobject") {
+    new BsonObject().bsonValue.to[BsonObject] shouldBe Right(new BsonObject())
+  }
+
+  test("decode a bsonarray") {
+    new BsonArray().bsonValue.to[BsonArray] shouldBe Right(new BsonArray())
+  }
+
+}

--- a/mewbase-rest-http4s/src/main/scala/io.mewbase.rest.http4s/MewbaseSupport.scala
+++ b/mewbase-rest-http4s/src/main/scala/io.mewbase.rest.http4s/MewbaseSupport.scala
@@ -1,0 +1,16 @@
+package io.mewbase.rest.http4s
+
+import cats.effect.Effect
+import io.mewbase.rest.RestServiceAction
+import org.http4s.Response
+
+import scala.language.higherKinds
+
+trait MewbaseSupport {
+
+  implicit def mewbaseServiceActionToResponse[F[_]: Effect](serviceAction: RestServiceAction[_]): F[Response[F]] = {
+    val serviceActionVisitor = new Http4sRestServiceActionVisitor[F]
+    serviceAction.visit(serviceActionVisitor)
+  }
+
+}


### PR DESCRIPTION
The aim of this PR is to make Scala support in mewbase more idiomatic, see

```
examples-scala/src/main/scala/example/gettingstarted/commandrest/Main.scala
```
For an example of the outcome (we can go further to making more idiomatic Scala support - so this should be considered WIP).

The main contributions are:

- Cleaner support for Http4s: mixing the trait `MewbaseSupport` into a `HttpService` allows you to directly expose mewbase REST service actions
 - Implicit syntax for building and manipulating `BsonObject` and `BsonArray`. This syntax is based upon the Circe's JSON libraries syntax, and helps ensure type safety